### PR TITLE
Fix build for kernel version > 5.11

### DIFF
--- a/core/rtw_btcoex.c
+++ b/core/rtw_btcoex.c
@@ -1503,15 +1503,19 @@ u8 rtw_btcoex_sendmsgbysocket(_adapter *padapter, u8 *msg, u8 msg_size, bool for
 	udpmsg.msg_control	= NULL;
 	udpmsg.msg_controllen = 0;
 	udpmsg.msg_flags	= MSG_DONTWAIT | MSG_NOSIGNAL;
+#ifdef get_fs
 	oldfs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 	error = sock_sendmsg(pcoex_info->udpsock, &udpmsg);
 #else
 	error = sock_sendmsg(pcoex_info->udpsock, &udpmsg, msg_size);
 #endif
+#ifdef get_fs
 	set_fs(oldfs);
+#endif
 	if (error < 0) {
 		RTW_INFO("Error when sendimg msg, error:%d\n", error);
 		return _FAIL;

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -4969,8 +4969,10 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 		return 0;
 	}
 
+#ifdef get_fs
 	fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 
 	source = rtw_zmalloc(2048);
 
@@ -4980,7 +4982,9 @@ int rtw_dev_nlo_info_set(struct pno_nlo_info *nlo_info, pno_ssid_t *ssid,
 		rtw_mfree(source, 2048);
 	}
 
+#ifdef get_fs
 	set_fs(fs);
+#endif
 	filp_close(fp, NULL);
 
 	RTW_INFO("-%s-\n", __func__);

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -456,7 +456,11 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
 	if (started) {
+		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
+		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, false);
+		#else
 		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0);
+		#endif
 		goto exit;
 	}
 #endif

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -4304,15 +4304,18 @@ static int route_dump(u32 *gw_addr , int *gw_index)
 	msg.msg_controllen = 0;
 	msg.msg_flags = MSG_DONTWAIT;
 
+#ifdef get_fs
 	oldfs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 	err = sock_sendmsg(sock, &msg);
 #else
 	err = sock_sendmsg(sock, &msg, sizeof(req));
 #endif
+#ifdef get_fs
 	set_fs(oldfs);
-
+#endif
 	if (err < 0)
 		goto out_sock;
 
@@ -4336,15 +4339,18 @@ restart:
 		iov_iter_init(&msg.msg_iter, READ, &iov, 1, PAGE_SIZE);
 #endif
 
+#ifdef get_fs
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0))
 		err = sock_recvmsg(sock, &msg, MSG_DONTWAIT);
 #else
 		err = sock_recvmsg(sock, &msg, PAGE_SIZE, MSG_DONTWAIT);
 #endif
+#ifdef get_fs
 		set_fs(oldfs);
-
+#endif
 		if (err < 0)
 			goto out_sock_pg;
 
@@ -4414,14 +4420,18 @@ done:
 		msg.msg_controllen = 0;
 		msg.msg_flags = MSG_DONTWAIT;
 
+#ifdef get_fs
 		oldfs = get_fs();
 		set_fs(KERNEL_DS);
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0))
 		err = sock_sendmsg(sock, &msg);
 #else
 		err = sock_sendmsg(sock, &msg, sizeof(req));
 #endif
+#ifdef get_fs
 		set_fs(oldfs);
+#endif
 
 		if (err > 0)
 			goto restart;

--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -355,8 +355,14 @@ static int napi_recv(_adapter *padapter, int budget)
 
 #ifdef CONFIG_RTW_GRO
 		if (pregistrypriv->en_gro) {
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0))
+			rtw_napi_gro_receive(&padapter->napi, pskb);
+			rx_ok = _TRUE;
+#else
 			if (rtw_napi_gro_receive(&padapter->napi, pskb) != GRO_DROP)
 				rx_ok = _TRUE;
+#endif
 			goto next;
 		}
 #endif /* CONFIG_RTW_GRO */

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -2238,13 +2238,14 @@ static int isFileReadable(const char *path, u32 *sz)
 	if (IS_ERR(fp))
 		ret = PTR_ERR(fp);
 	else {
+#ifdef get_fs
 		oldfs = get_fs();
 		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
 		set_fs(KERNEL_DS);
 		#else
 		set_fs(get_ds());
 		#endif
-
+#endif
 		if (1 != readFile(fp, &buf, 1))
 			ret = PTR_ERR(fp);
 
@@ -2256,7 +2257,9 @@ static int isFileReadable(const char *path, u32 *sz)
 			#endif
 		}
 
+#ifdef get_fs
 		set_fs(oldfs);
+#endif
 		filp_close(fp, NULL);
 	}
 	return ret;
@@ -2280,14 +2283,18 @@ static int retriveFromFile(const char *path, u8 *buf, u32 sz)
 		if (0 == ret) {
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
+#ifdef get_fs
 			oldfs = get_fs();
 			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
 			set_fs(KERNEL_DS);
 			#else
 			set_fs(get_ds());
 			#endif
+#endif
 			ret = readFile(fp, buf, sz);
+#ifdef get_fs
 			set_fs(oldfs);
+#endif
 			closeFile(fp);
 
 			RTW_INFO("%s readFile, ret:%d\n", __FUNCTION__, ret);
@@ -2319,14 +2326,18 @@ static int storeToFile(const char *path, u8 *buf, u32 sz)
 		if (0 == ret) {
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
+#ifdef get_fs
 			oldfs = get_fs();
 			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0))
 			set_fs(KERNEL_DS);
 			#else
 			set_fs(get_ds());
 			#endif
+#endif
 			ret = writeFile(fp, buf, sz);
+#ifdef get_fs
 			set_fs(oldfs);
+#endif
 			closeFile(fp);
 
 			RTW_INFO("%s writeFile, ret:%d\n", __FUNCTION__, ret);


### PR DESCRIPTION
Fix build for kernel version > 5.11
via https://lwn.net/Articles/832121/ "Saying goodbye to set_fs()"
via https://lore.kernel.org/r/iwlwifi.20201129172929.8953ef22cc64.Ifee9cab337a4369938545920ba5590559e91327a@changeid  "In the NL80211_CMD_CH_SWITCH_STARTED_NOTIFY event, include the
NL80211_ATTR_CH_SWITCH_BLOCK_TX flag attribute if block-tx was
requested by the AP."
