### PR TITLE
core/crypto/sha256.h: fix for kernel 6.18

### DIFF
--- a/core/crypto/sha256.h
+++ b/core/crypto/sha256.h
@@ -15,8 +15,10 @@
 int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 		       const u8 *addr[], const size_t *len, u8 *mac);
 #endif
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 0))
 int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
 		size_t data_len, u8 *mac);
+#endif
 int sha256_prf(const u8 *key, size_t key_len, const char *label,
 	       const u8 *data, size_t data_len, u8 *buf, size_t buf_len);
 int sha256_prf_bits(const u8 *key, size_t key_len, const char *label,


### PR DESCRIPTION
Update driver for kernel 6.18+

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add kernel version guard to only declare `hmac_sha256` in `core/crypto/sha256.h` for kernels < 6.18 to maintain compatibility with 6.18+.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39f72eab042da8d74a2c9753cb5865caf103d93c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->