### PR TITLE
Fix compatibility issues for kernel 7.1+ in PPPoE and cfg80211

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -89,7 +89,17 @@ static __inline__ unsigned char *__nat25_find_pppoe_tag(struct pppoe_hdr *ph, un
 	unsigned char *cur_ptr, *start_ptr;
 	unsigned short tagLen, tagType;
 
+	/*
+	 * Upstream commit 7717fbb14028 ("net: pppoe: avoid zero-length arrays
+	 * in struct pppoe_hdr"), in v7.1-rc1, hides struct pppoe_hdr::tag[]
+	 * and struct pppoe_tag::tag_data[] behind #ifndef __KERNEL__. The
+	 * on-wire layout is unchanged, so step past the fixed-size header.
+	 */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	start_ptr = cur_ptr = (unsigned char *)(ph + 1);
+#else
 	start_ptr = cur_ptr = (unsigned char *)ph->tag;
+#endif
 	while ((cur_ptr - start_ptr) < ntohs(ph->length)) {
 		/* prevent un-alignment access */
 		tagType = (unsigned short)((cur_ptr[0] << 8) + cur_ptr[1]);
@@ -115,9 +125,18 @@ static __inline__ int __nat25_add_pppoe_tag(struct sk_buff *skb, struct pppoe_ta
 
 	skb_put(skb, data_len);
 	/* have a room for new tag */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	/* upstream 7717fbb14028: pppoe_hdr::tag[] hidden from kernel */
+	memmove((unsigned char *)(ph + 1) + data_len, (unsigned char *)(ph + 1), ntohs(ph->length));
+#else
 	memmove(((unsigned char *)ph->tag + data_len), (unsigned char *)ph->tag, ntohs(ph->length));
+#endif
 	ph->length = htons(ntohs(ph->length) + data_len);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	memcpy((unsigned char *)(ph + 1), tag, data_len);
+#else
 	memcpy((unsigned char *)ph->tag, tag, data_len);
+#endif
 	return data_len;
 }
 
@@ -1146,8 +1165,14 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 								return -1;
 							}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+							/* upstream 7717fbb14028: pppoe_tag::tag_data[] hidden from kernel */
+							memcpy((unsigned char *)(tag + 1) + MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN,
+							       (unsigned char *)(pOldTag + 1), old_tag_len);
+#else
 							memcpy(tag->tag_data + MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN,
 							       pOldTag->tag_data, old_tag_len);
+#endif
 
 							if (skb_pull_and_merge(skb, (unsigned char *)pOldTag, TAG_HDR_LEN + old_tag_len) < 0) {
 								DEBUG_ERR("call skb_pull_and_merge() failed in PADI/R packet!\n");
@@ -1160,9 +1185,18 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 						tag->tag_len = htons(MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN + old_tag_len);
 
 						/* insert the magic_code+client mac in relay tag */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+						/* upstream 7717fbb14028: pppoe_tag::tag_data[] hidden from kernel */
+						pMagic = (unsigned short *)(tag + 1);
+#else
 						pMagic = (unsigned short *)tag->tag_data;
+#endif
 						*pMagic = htons(MAGIC_CODE);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+						memcpy((unsigned char *)(tag + 1) + MAGIC_CODE_LEN, skb->data + ETH_ALEN, ETH_ALEN);
+#else
 						memcpy(tag->tag_data + MAGIC_CODE_LEN, skb->data + ETH_ALEN, ETH_ALEN);
+#endif
 
 						/* Add relay tag */
 						if (__nat25_add_pppoe_tag(skb, tag) < 0)
@@ -1223,14 +1257,24 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 						return -1;
 					}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+					/* upstream 7717fbb14028: pppoe_tag::tag_data[] hidden from kernel */
+					pMagic = (unsigned short *)(tag + 1);
+#else
 					pMagic = (unsigned short *)tag->tag_data;
+#endif
 					if (ntohs(*pMagic) != MAGIC_CODE) {
 						DEBUG_ERR("Can't find MAGIC_CODE in %s packet!\n",
 							(ph->code == PADO_CODE ? "PADO" : "PADS"));
 						return -1;
 					}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+					/* upstream 7717fbb14028: pppoe_tag::tag_data[] hidden from kernel */
+					memcpy(skb->data, (unsigned char *)(tag + 1) + MAGIC_CODE_LEN, ETH_ALEN);
+#else
 					memcpy(skb->data, tag->tag_data + MAGIC_CODE_LEN, ETH_ALEN);
+#endif
 
 					if (tagLen > MAGIC_CODE_LEN + RTL_RELAY_TAG_LEN)
 						offset = TAG_HDR_LEN;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1918,7 +1918,13 @@ exit:
 	return ret;
 }
 
-static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct net_device *ndev
+static int cfg80211_rtw_add_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	/* upstream 033fe322f585: cfg80211 key callbacks take wireless_dev * */
+	struct wireless_dev *wdev
+#else
+	struct net_device *ndev
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 	, int link_id
 #endif
@@ -1928,6 +1934,9 @@ static int cfg80211_rtw_add_key(struct wiphy *wiphy, struct net_device *ndev
 #endif
 	, const u8 *mac_addr, struct key_params *params)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev->netdev;
+#endif
 	char *alg_name;
 	u32 param_len;
 	struct ieee_param *param = NULL;
@@ -2083,7 +2092,13 @@ addkey_end:
 
 }
 
-static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct net_device *ndev
+static int cfg80211_rtw_get_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	/* upstream 033fe322f585: cfg80211 key callbacks take wireless_dev * */
+	struct wireless_dev *wdev
+#else
+	struct net_device *ndev
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 	, int link_id
 #endif
@@ -2094,6 +2109,9 @@ static int cfg80211_rtw_get_key(struct wiphy *wiphy, struct net_device *ndev
 	, const u8 *mac_addr, void *cookie
 	, void (*callback)(void *cookie, struct key_params *))
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev->netdev;
+#endif
 #define GET_KEY_PARAM_FMT_S " keyid=%d"
 #define GET_KEY_PARAM_ARG_S , keyid
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) || defined(COMPAT_KERNEL_RELEASE)
@@ -2274,7 +2292,13 @@ exit:
 	return ret;
 }
 
-static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct net_device *ndev,
+static int cfg80211_rtw_del_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+				/* upstream 033fe322f585: cfg80211 key callbacks take wireless_dev * */
+				struct wireless_dev *wdev,
+#else
+				struct net_device *ndev,
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 				int link_id,
 #endif
@@ -2284,6 +2308,9 @@ static int cfg80211_rtw_del_key(struct wiphy *wiphy, struct net_device *ndev,
 				u8 key_index, const u8 *mac_addr)
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) */
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev->netdev;
+#endif
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct security_priv *psecuritypriv = &padapter->securitypriv;
 
@@ -2350,12 +2377,20 @@ static int cfg80211_rtw_set_default_key(struct wiphy *wiphy,
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 30))
 int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	/* upstream 033fe322f585: set_default_mgmt_key takes wireless_dev * */
+	struct wireless_dev *wdev
+#else
 	struct net_device *ndev
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
 	, int link_id
 #endif
 	, u8 key_index)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev->netdev;
+#endif
 #define SET_DEF_KEY_PARAM_FMT " key_index=%d"
 #define SET_DEF_KEY_PARAM_ARG , key_index
 
@@ -2500,7 +2535,12 @@ static void rtw_cfg80211_fill_mesh_only_sta_info(struct mesh_plink_ent *plink, s
 #endif /* CONFIG_RTW_MESH */
 
 static int cfg80211_rtw_get_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	/* upstream 033fe322f585: cfg80211 station callbacks take wireless_dev * */
+	struct wireless_dev *wdev,
+#else
 	struct net_device *ndev,
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
 #else
@@ -2508,6 +2548,9 @@ static int cfg80211_rtw_get_station(struct wiphy *wiphy,
 #endif
 	struct station_info *sinfo)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev->netdev;
+#endif
 	int ret = 0;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct mlme_priv *pmlmepriv = &padapter->mlmepriv;
@@ -4801,7 +4844,12 @@ void rtw_cfg80211_indicate_sta_assoc(_adapter *padapter, u8 *pmgmt_frame, uint f
 		sinfo.filled = STATION_INFO_ASSOC_REQ_IES;
 		sinfo.assoc_req_ies = pmgmt_frame + WLAN_HDR_A3_LEN + ie_offset;
 		sinfo.assoc_req_ies_len = frame_len - WLAN_HDR_A3_LEN - ie_offset;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+		/* upstream 033fe322f585: cfg80211_new_sta() takes wireless_dev * */
+		cfg80211_new_sta(ndev->ieee80211_ptr, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
+#else
 		cfg80211_new_sta(ndev, get_addr2_ptr(pmgmt_frame), &sinfo, GFP_ATOMIC);
+#endif
 	}
 #else /* defined(RTW_USE_CFG80211_STA_EVENT) */
 	channel = pmlmeext->cur_channel;
@@ -4847,7 +4895,12 @@ void rtw_cfg80211_indicate_sta_disassoc(_adapter *padapter, const u8 *da, unsign
 	RTW_INFO(FUNC_ADPT_FMT"\n", FUNC_ADPT_ARG(padapter));
 
 #if defined(RTW_USE_CFG80211_STA_EVENT) || defined(COMPAT_KERNEL_RELEASE)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	/* upstream 033fe322f585: cfg80211_del_sta() takes wireless_dev * */
+	cfg80211_del_sta(ndev->ieee80211_ptr, da, GFP_ATOMIC);
+#else
 	cfg80211_del_sta(ndev, da, GFP_ATOMIC);
+#endif
 #else /* defined(RTW_USE_CFG80211_STA_EVENT) */
 	channel = pmlmeext->cur_channel;
 	freq = rtw_ch2freq(channel);
@@ -5813,7 +5866,13 @@ void dump_station_parameters(void *sel, struct wiphy *wiphy, const struct statio
 #endif /* DBG_RTW_CFG80211_STA_PARAM */
 }
 
-static int	cfg80211_rtw_add_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_add_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	/* upstream 033fe322f585: cfg80211 station callbacks take wireless_dev * */
+	struct wireless_dev *wdev,
+#else
+	struct net_device *ndev,
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
 #else
@@ -5821,6 +5880,9 @@ static int	cfg80211_rtw_add_station(struct wiphy *wiphy, struct net_device *ndev
 #endif
 	struct station_parameters *params)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev->netdev;
+#endif
 	int ret = 0;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 #if defined(CONFIG_TDLS) || defined(CONFIG_RTW_MESH)
@@ -5959,7 +6021,12 @@ release_plink_ctl:
 
 			/* indicate new sta */
 			_rtw_memset(&sinfo, 0, sizeof(sinfo));
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+			/* upstream 033fe322f585: cfg80211_new_sta() takes wireless_dev * */
+			cfg80211_new_sta(ndev->ieee80211_ptr, mac, &sinfo, GFP_ATOMIC);
+#else
 			cfg80211_new_sta(ndev, mac, &sinfo, GFP_ATOMIC);
+#endif
 		}
 		goto exit;
 	}
@@ -5981,7 +6048,13 @@ exit:
 	return ret;
 }
 
-static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_del_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	/* upstream 033fe322f585: cfg80211 station callbacks take wireless_dev * */
+	struct wireless_dev *wdev,
+#else
+	struct net_device *ndev,
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0))
@@ -5991,6 +6064,9 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 #endif
 )
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev->netdev;
+#endif
 	int ret = 0;
 	_irqL irqL;
 	_list	*phead, *plist;
@@ -6105,7 +6181,13 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy, struct net_device *ndev
 
 }
 
-static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_change_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	/* upstream 033fe322f585: cfg80211 station callbacks take wireless_dev * */
+	struct wireless_dev *wdev,
+#else
+	struct net_device *ndev,
+#endif
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0))
 	u8 *mac,
 #else
@@ -6113,6 +6195,9 @@ static int	cfg80211_rtw_change_station(struct wiphy *wiphy, struct net_device *n
 #endif
 	struct station_parameters *params)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev->netdev;
+#endif
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
 	int ret = 0;
 
@@ -6171,9 +6256,18 @@ struct sta_info *rtw_sta_info_get_by_idx(struct sta_priv *pstapriv, const int id
 	return psta;
 }
 
-static int	cfg80211_rtw_dump_station(struct wiphy *wiphy, struct net_device *ndev,
+static int	cfg80211_rtw_dump_station(struct wiphy *wiphy,
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+		/* upstream 033fe322f585: cfg80211 station callbacks take wireless_dev * */
+		struct wireless_dev *wdev,
+#else
+		struct net_device *ndev,
+#endif
 		int idx, u8 *mac, struct station_info *sinfo)
 {
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
+	struct net_device *ndev = wdev->netdev;
+#endif
 #define DBG_DUMP_STATION 0
 
 	int ret = 0;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1935,7 +1935,11 @@ static int cfg80211_rtw_add_key(struct wiphy *wiphy,
 	, const u8 *mac_addr, struct key_params *params)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
-	struct net_device *ndev = wdev->netdev;
+	/* P2P device wdev (NL80211_IFTYPE_P2P_DEVICE) has no netdev */
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
 #endif
 	char *alg_name;
 	u32 param_len;
@@ -2110,7 +2114,11 @@ static int cfg80211_rtw_get_key(struct wiphy *wiphy,
 	, void (*callback)(void *cookie, struct key_params *))
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
-	struct net_device *ndev = wdev->netdev;
+	/* P2P device wdev (NL80211_IFTYPE_P2P_DEVICE) has no netdev */
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
 #endif
 #define GET_KEY_PARAM_FMT_S " keyid=%d"
 #define GET_KEY_PARAM_ARG_S , keyid
@@ -2309,7 +2317,11 @@ static int cfg80211_rtw_del_key(struct wiphy *wiphy,
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37)) */
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
-	struct net_device *ndev = wdev->netdev;
+	/* P2P device wdev (NL80211_IFTYPE_P2P_DEVICE) has no netdev */
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
 #endif
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
 	struct security_priv *psecuritypriv = &padapter->securitypriv;
@@ -2389,7 +2401,11 @@ int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
 	, u8 key_index)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
-	struct net_device *ndev = wdev->netdev;
+	/* P2P device wdev (NL80211_IFTYPE_P2P_DEVICE) has no netdev */
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
 #endif
 #define SET_DEF_KEY_PARAM_FMT " key_index=%d"
 #define SET_DEF_KEY_PARAM_ARG , key_index
@@ -2549,7 +2565,11 @@ static int cfg80211_rtw_get_station(struct wiphy *wiphy,
 	struct station_info *sinfo)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
-	struct net_device *ndev = wdev->netdev;
+	/* P2P device wdev (NL80211_IFTYPE_P2P_DEVICE) has no netdev */
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
 #endif
 	int ret = 0;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
@@ -5881,7 +5901,11 @@ static int	cfg80211_rtw_add_station(struct wiphy *wiphy,
 	struct station_parameters *params)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
-	struct net_device *ndev = wdev->netdev;
+	/* P2P device wdev (NL80211_IFTYPE_P2P_DEVICE) has no netdev */
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
 #endif
 	int ret = 0;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
@@ -6065,7 +6089,11 @@ static int	cfg80211_rtw_del_station(struct wiphy *wiphy,
 )
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
-	struct net_device *ndev = wdev->netdev;
+	/* P2P device wdev (NL80211_IFTYPE_P2P_DEVICE) has no netdev */
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
 #endif
 	int ret = 0;
 	_irqL irqL;
@@ -6196,7 +6224,11 @@ static int	cfg80211_rtw_change_station(struct wiphy *wiphy,
 	struct station_parameters *params)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
-	struct net_device *ndev = wdev->netdev;
+	/* P2P device wdev (NL80211_IFTYPE_P2P_DEVICE) has no netdev */
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
 #endif
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
 	int ret = 0;
@@ -6266,7 +6298,11 @@ static int	cfg80211_rtw_dump_station(struct wiphy *wiphy,
 		int idx, u8 *mac, struct station_info *sinfo)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
-	struct net_device *ndev = wdev->netdev;
+	/* P2P device wdev (NL80211_IFTYPE_P2P_DEVICE) has no netdev */
+	struct net_device *ndev = wdev_to_ndev(wdev);
+
+	if (!ndev)
+		return -EINVAL;
 #endif
 #define DBG_DUMP_STATION 0
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to conditional pointer arithmetic/memmove changes in PPPoE tag parsing and widespread `cfg80211` callback signature changes that could break association/key management on newer kernels if incorrect.
> 
> **Overview**
> Improves Linux 7.1+ compatibility by updating PPPoE relay-tag handling to avoid direct access to `pppoe_hdr::tag[]` / `pppoe_tag::tag_data[]`, instead operating on the bytes immediately following the fixed headers when building/searching/removing tags.
> 
> Updates multiple `cfg80211` callbacks (key management, default mgmt key, and station add/del/change/dump/get) to match the upstream 7.1 API that passes `struct wireless_dev *`, including safe `wdev_to_ndev()` conversion and returning `-EINVAL` when no netdev exists (e.g., P2P device).
> 
> Adds `.github/dependabot.yml` to enable weekly GitHub Actions dependency checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4e1c78b77db0c4af33127366ec3c3387b5d7cbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->