### PR TITLE
Fix endian bug in __nat25_add_pppoe_tag (PPPoE relay tag dead on LE)

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -117,7 +117,14 @@ static __inline__ int __nat25_add_pppoe_tag(struct sk_buff *skb, struct pppoe_ta
 	struct pppoe_hdr *ph = (struct pppoe_hdr *)(skb->data + ETH_HLEN);
 	int data_len;
 
-	data_len = tag->tag_len + TAG_HDR_LEN;
+	/*
+	 * pppoe_tag::tag_len is __be16 (always network byte order); callers
+	 * fill it via htons(...) and other paths read it via ntohs(). Without
+	 * the conversion, on little-endian systems data_len would be
+	 * byte-swapped, skb_tailroom() would fail almost always and the
+	 * relay-tag path would silently fail.
+	 */
+	data_len = ntohs(tag->tag_len) + TAG_HDR_LEN;
 	if (skb_tailroom(skb) < data_len) {
 		_DEBUG_ERR("skb_tailroom() failed in add SID tag!\n");
 		return -1;


### PR DESCRIPTION
## Summary

- `__nat25_add_pppoe_tag()` derived `data_len` from `tag->tag_len` (which is `__be16`) without an `ntohs()` conversion.
- On little-endian platforms (the entire meson64 ARM64 lineup, x86, etc.), this byte-swaps the value: a typical PADI/PADR relay tag with `tag->tag_len = htons(8)` would compute `data_len = 0x0800 + 4 = 2052`, causing `skb_tailroom() < data_len` to fail and the tag to be silently dropped.
- The PPPoE relay-tag feature (`addPPPoETag=1` in bridge ext) has effectively been dead-on-arrival on LE for as long as this driver has shipped.

## Background

Spotted by Copilot review on #20 (kernel 7.1 compat). Pre-existing in upstream Realtek.

## Fix

One-line change: use `ntohs(tag->tag_len)` when computing `data_len`. All subsequent `skb_tailroom()` / `skb_put()` / `memmove()` / `memcpy()` calls and the `ph->length` update then see a correct host-order length.

## Test plan

- [x] Cross-compiles cleanly on v7.1-rc1 (`LD [M] drivers/net/wireless/rtl88x2cs/88x2cs.o`).
- [ ] CI matrix (v6.1.x .. v6.19.x) — relies on existing `Test Build` workflow.
- [ ] Functional check: PPPoE relay tag now actually inserted on a meson64 board with `addPPPoETag=1` (manual; not blocking merge since old behavior was equivalent to "feature off").

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches in-kernel packet buffer sizing/mutation for PPPoE frames; while the change is small and localized, mistakes here could corrupt packets or break PPPoE relay behavior.
> 
> **Overview**
> Fixes PPPoE relay-tag insertion in `__nat25_add_pppoe_tag()` by converting `pppoe_tag::tag_len` from network to host byte order when computing the amount of data to append.
> 
> This prevents little-endian systems from miscomputing `data_len`, failing `skb_tailroom()` checks, and silently skipping relay tag insertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ff5bd5b016ab94c7a4a13c5cdd584b86896bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->