### PR TITLE
 Fix some build errors for kernel with -Werror option

### DIFF
--- a/core/crypto/ccmp.c
+++ b/core/crypto/ccmp.c
@@ -175,7 +175,7 @@ u8 * ccmp_decrypt(const u8 *tk, const struct ieee80211_hdr *hdr,
 }
 
 
-void ccmp_get_pn(u8 *pn, const u8 *data)
+static void ccmp_get_pn(u8 *pn, const u8 *data)
 {
 	pn[0] = data[7]; /* PN5 */
 	pn[1] = data[6]; /* PN4 */

--- a/core/efuse/rtw_efuse.c
+++ b/core/efuse/rtw_efuse.c
@@ -56,7 +56,7 @@ BOOLEAN rtw_file_efuse_IsMasked(PADAPTER pAdapter, u16 Offset, u8 *maskbuf)
 
 	return (result > 0) ? 0 : 1;
 }
-BOOLEAN efuse_IsBT_Masked(PADAPTER pAdapter, u16 Offset)
+static BOOLEAN efuse_IsBT_Masked(PADAPTER pAdapter, u16 Offset)
 {
 	PHAL_DATA_TYPE pHalData = GET_HAL_DATA(pAdapter);
 
@@ -921,7 +921,7 @@ out_free_buffer:
 		rtw_mfree((u8 *)eFuseWord, EFUSE_MAX_SECTION_NUM * (EFUSE_MAX_WORD_UNIT * 2));
 }
 
-void efuse_PreUpdateAction(
+static void efuse_PreUpdateAction(
 	PADAPTER	pAdapter,
 	u32			*BackupRegs)
 {
@@ -950,7 +950,7 @@ void efuse_PreUpdateAction(
 }
 
 
-void efuse_PostUpdateAction(
+static void efuse_PostUpdateAction(
 	PADAPTER	pAdapter,
 	u32			*BackupRegs)
 {

--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -953,7 +953,7 @@ _exit:
 }
 #endif
 
-void rtw_init_bmc_sta_tx_rate(_adapter *padapter, struct sta_info *psta)
+static void rtw_init_bmc_sta_tx_rate(_adapter *padapter, struct sta_info *psta)
 {
 #ifdef CONFIG_BMC_TX_LOW_RATE
 	struct mlme_ext_priv *pmlmeext = &(padapter->mlmeextpriv);
@@ -1040,7 +1040,7 @@ void update_bmc_sta(_adapter *padapter)
 }
 
 #if defined(CONFIG_80211N_HT) && defined(CONFIG_BEAMFORMING)
-void update_sta_info_apmode_ht_bf_cap(_adapter *padapter, struct sta_info *psta)
+static void update_sta_info_apmode_ht_bf_cap(_adapter *padapter, struct sta_info *psta)
 {
 	struct mlme_priv *pmlmepriv = &(padapter->mlmepriv);
 	struct ht_priv	*phtpriv_ap = &pmlmepriv->htpriv;
@@ -2847,7 +2847,7 @@ int rtw_ap_set_wep_key(_adapter *padapter, u8 *key, u8 keylen, int keyid, u8 set
 	return rtw_ap_set_key(padapter, key, alg, keyid, set_tx);
 }
 
-u8 rtw_ap_bmc_frames_hdl(_adapter *padapter)
+static u8 rtw_ap_bmc_frames_hdl(_adapter *padapter)
 {
 #define HIQ_XMIT_COUNTS (6)
 	_irqL irqL;

--- a/core/rtw_chplan.c
+++ b/core/rtw_chplan.c
@@ -426,7 +426,7 @@ bool rtw_chplan_is_empty(u8 id)
 	return _FALSE;
 }
 
-bool rtw_regsty_is_excl_chs(struct registry_priv *regsty, u8 ch)
+static bool rtw_regsty_is_excl_chs(struct registry_priv *regsty, u8 ch)
 {
 	int i;
 

--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -1620,7 +1620,7 @@ exit:
 
 }
 
-void free_assoc_resources_hdl(_adapter *padapter, u8 lock_scanned_queue)
+static void free_assoc_resources_hdl(_adapter *padapter, u8 lock_scanned_queue)
 {
 #ifdef CONFIG_SUPPORT_DYNAMIC_TXPWR
 	struct wlan_network *pcur_nw = &(padapter->mlmepriv.cur_network);
@@ -1793,7 +1793,7 @@ exit:
 	return res;
 }
 
-u8 _rtw_set_chplan_cmd(_adapter *adapter, int flags, u8 chplan, const struct country_chplan *country_ent, u8 swconfig)
+static u8 _rtw_set_chplan_cmd(_adapter *adapter, int flags, u8 chplan, const struct country_chplan *country_ent, u8 swconfig)
 {
 	struct cmd_obj *cmdobj;
 	struct	SetChannelPlan_param *parm;
@@ -2065,7 +2065,7 @@ u8 rtw_periodic_tsf_update_end_cmd(_adapter *adapter)
 exit:
 	return res;
 }
-u8 rtw_ssmps_wk_hdl(_adapter *adapter, struct ssmps_cmd_parm *ssmp_param)
+static u8 rtw_ssmps_wk_hdl(_adapter *adapter, struct ssmps_cmd_parm *ssmp_param)
 {
 	u8 res = _SUCCESS;
 	struct sta_info *sta = ssmp_param->sta;
@@ -2841,7 +2841,7 @@ void rtw_iface_dynamic_chk_wk_hdl(_adapter *padapter)
 
 
 }
-void rtw_dynamic_chk_wk_hdl(_adapter *padapter)
+static void rtw_dynamic_chk_wk_hdl(_adapter *padapter)
 {
 	rtw_mi_dynamic_chk_wk_hdl(padapter);
 #ifdef CONFIG_MP_INCLUDED
@@ -2890,7 +2890,7 @@ struct lps_ctrl_wk_parm {
 	#endif
 };
 
-void lps_ctrl_wk_hdl(_adapter *padapter, u8 lps_ctrl_type, u8 *buf)
+static void lps_ctrl_wk_hdl(_adapter *padapter, u8 lps_ctrl_type, u8 *buf)
 {
 	struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
 	struct mlme_priv *pmlmepriv = &(padapter->mlmepriv);
@@ -3069,7 +3069,7 @@ u8 rtw_lps_ctrl_leave_set_1t1r_cmd(_adapter *adapter, u8 lps_1t1r, u8 flags)
 }
 #endif
 
-void rtw_dm_in_lps_hdl(_adapter *padapter)
+static void rtw_dm_in_lps_hdl(_adapter *padapter)
 {
 	rtw_hal_set_hwreg(padapter, HW_VAR_DM_IN_LPS_LCLK, NULL);
 }
@@ -3110,7 +3110,7 @@ exit:
 
 }
 
-void rtw_lps_change_dtim_hdl(_adapter *padapter, u8 dtim)
+static void rtw_lps_change_dtim_hdl(_adapter *padapter, u8 dtim)
 {
 	struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
 
@@ -3289,7 +3289,7 @@ exit:
 }
 #endif
 
-void rtw_dm_ra_mask_hdl(_adapter *padapter, struct sta_info *psta)
+static void rtw_dm_ra_mask_hdl(_adapter *padapter, struct sta_info *psta)
 {
 	if (psta)
 		set_sta_rate(padapter, psta);
@@ -3331,13 +3331,13 @@ exit:
 
 }
 
-void power_saving_wk_hdl(_adapter *padapter)
+static void power_saving_wk_hdl(_adapter *padapter)
 {
 	rtw_ps_processor(padapter);
 }
 
 /* add for CONFIG_IEEE80211W, none 11w can use it */
-void reset_securitypriv_hdl(_adapter *padapter)
+static void reset_securitypriv_hdl(_adapter *padapter)
 {
 	rtw_reset_securitypriv(padapter);
 }
@@ -3763,7 +3763,7 @@ exit:
 }
 
 #ifdef CONFIG_DFS_MASTER
-u8 rtw_dfs_rd_hdl(_adapter *adapter)
+static u8 rtw_dfs_rd_hdl(_adapter *adapter)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
@@ -4154,7 +4154,7 @@ struct btinfo {
 	u8 rsvd_7;
 };
 
-void btinfo_evt_dump(void *sel, void *buf)
+static void btinfo_evt_dump(void *sel, void *buf)
 {
 	struct btinfo *info = (struct btinfo *)buf;
 
@@ -4627,7 +4627,7 @@ inline u8 rtw_customer_str_write_cmd(_adapter *adapter, const u8 *cstr)
 }
 #endif /* CONFIG_RTW_CUSTOMER_STR */
 
-u8 rtw_c2h_wk_cmd(PADAPTER padapter, u8 *pbuf, u16 length, u8 type)
+static u8 rtw_c2h_wk_cmd(PADAPTER padapter, u8 *pbuf, u16 length, u8 type)
 {
 	struct cmd_obj *ph2c;
 	struct drvextra_cmd_parm *pdrvextra_cmd_parm;
@@ -4767,7 +4767,7 @@ exit:
 }
 #endif /* CONFIG_FW_C2H_REG */
 
-u8 session_tracker_cmd(_adapter *adapter, u8 cmd, struct sta_info *sta, u8 *local_naddr, u8 *local_port, u8 *remote_naddr, u8 *remote_port)
+static u8 session_tracker_cmd(_adapter *adapter, u8 cmd, struct sta_info *sta, u8 *local_naddr, u8 *local_port, u8 *remote_naddr, u8 *remote_port)
 {
 	struct cmd_priv	*cmdpriv = &adapter->cmdpriv;
 	struct cmd_obj *cmdobj;
@@ -4833,7 +4833,7 @@ inline u8 session_tracker_del_cmd(_adapter *adapter, struct sta_info *sta, u8 *l
 	return session_tracker_cmd(adapter, ST_CMD_DEL, sta, local_naddr, local_port, remote_naddr, remote_port);
 }
 
-void session_tracker_chk_for_sta(_adapter *adapter, struct sta_info *sta)
+static void session_tracker_chk_for_sta(_adapter *adapter, struct sta_info *sta)
 {
 	struct st_ctl_t *st_ctl = &sta->st_ctl;
 	int i;
@@ -4915,7 +4915,7 @@ exit:
 	return;
 }
 
-void session_tracker_chk_for_adapter(_adapter *adapter)
+static void session_tracker_chk_for_adapter(_adapter *adapter)
 {
 	struct sta_priv *stapriv = &adapter->stapriv;
 	struct sta_info *sta;
@@ -4947,7 +4947,7 @@ void session_tracker_chk_for_adapter(_adapter *adapter)
 #endif
 }
 
-void session_tracker_cmd_hdl(_adapter *adapter, struct st_cmd_parm *parm)
+static void session_tracker_cmd_hdl(_adapter *adapter, struct st_cmd_parm *parm)
 {
 	u8 cmd = parm->cmd;
 	struct sta_info *sta = parm->sta;
@@ -5109,7 +5109,7 @@ exit:
 #endif
 
 
-void rtw_ac_parm_cmd_hdl(_adapter *padapter, u8 *_ac_parm_buf, int ac_type)
+static void rtw_ac_parm_cmd_hdl(_adapter *padapter, u8 *_ac_parm_buf, int ac_type)
 {
 
 	u32 ac_parm_buf;
@@ -5462,7 +5462,7 @@ exit:
 
 }
 
-void rtw_getrttbl_cmd_cmdrsp_callback(_adapter	*padapter,  struct cmd_obj *pcmd)
+static void rtw_getrttbl_cmd_cmdrsp_callback(_adapter	*padapter,  struct cmd_obj *pcmd)
 {
 
 	rtw_free_cmd_obj(pcmd);

--- a/core/rtw_ieee80211.c
+++ b/core/rtw_ieee80211.c
@@ -472,7 +472,7 @@ void rtw_set_supported_rate(u8 *SupportedRates, uint mode)
 	}
 }
 
-void rtw_filter_suppport_rateie(WLAN_BSSID_EX *pbss_network, u8 keep)
+static void rtw_filter_suppport_rateie(WLAN_BSSID_EX *pbss_network, u8 keep)
 {
 	u8 i, idx = 0, new_rate[NDIS_802_11_LENGTH_RATES_EX], *p;
 	uint iscck, isofdm, ie_orilen = 0, remain_len;
@@ -742,7 +742,7 @@ int rtw_get_rsn_cipher_suite(u8 *s)
 	return 0;
 }
 
-u32 rtw_get_akm_suite_bitmap(u8 *s)
+static u32 rtw_get_akm_suite_bitmap(u8 *s)
 {
 	if (_rtw_memcmp(s, WLAN_AKM_8021X, RSN_SELECTOR_LEN) == _TRUE)
 		return WLAN_AKM_TYPE_8021X;
@@ -1784,7 +1784,7 @@ void dump_ht_cap_ie_content(void *sel, const u8 *buf, u32 buf_len)
 		      , HT_SUP_MCS_SET_ARG(HT_CAP_ELE_SUP_MCS_SET(buf)));
 }
 
-void dump_ht_cap_ie(void *sel, const u8 *ie, u32 ie_len)
+static void dump_ht_cap_ie(void *sel, const u8 *ie, u32 ie_len)
 {
 	const u8 *ht_cap_ie;
 	sint ht_cap_ielen;
@@ -1803,7 +1803,7 @@ const char *const _ht_sc_offset_str[] = {
 	"SCB",
 };
 
-void dump_ht_op_ie_content(void *sel, const u8 *buf, u32 buf_len)
+static void dump_ht_op_ie_content(void *sel, const u8 *buf, u32 buf_len)
 {
 	if (buf_len != HT_OP_IE_LEN) {
 		RTW_PRINT_SEL(sel, "Invalid HT operation IE len:%d != %d\n", buf_len, HT_OP_IE_LEN);
@@ -1817,7 +1817,7 @@ void dump_ht_op_ie_content(void *sel, const u8 *buf, u32 buf_len)
 	);
 }
 
-void dump_ht_op_ie(void *sel, const u8 *ie, u32 ie_len)
+static void dump_ht_op_ie(void *sel, const u8 *ie, u32 ie_len)
 {
 	const u8 *ht_op_ie;
 	sint ht_op_ielen;

--- a/core/rtw_mi.c
+++ b/core/rtw_mi.c
@@ -881,7 +881,7 @@ void rtw_mi_buddy_xmit_tasklet_schedule(_adapter *padapter)
 }
 #endif
 
-u8 _rtw_mi_busy_traffic_check(_adapter *padapter, void *data)
+static u8 _rtw_mi_busy_traffic_check(_adapter *padapter, void *data)
 {
 	return padapter->mlmepriv.LinkDetectInfo.bBusyTraffic;
 }
@@ -1321,7 +1321,7 @@ _adapter *rtw_get_iface_by_hwport(_adapter *padapter, u8 hw_port)
 /*#define CONFIG_SKB_ALLOCATED*/
 #define DBG_SKB_PROCESS
 #ifdef DBG_SKB_PROCESS
-void rtw_dbg_skb_process(_adapter *padapter, union recv_frame *precvframe, union recv_frame *pcloneframe)
+static void rtw_dbg_skb_process(_adapter *padapter, union recv_frame *precvframe, union recv_frame *pcloneframe)
 {
 	_pkt *pkt_copy, *pkt_org;
 

--- a/core/rtw_mlme.c
+++ b/core/rtw_mlme.c
@@ -20,7 +20,7 @@ extern void indicate_wx_scan_complete_event(_adapter *padapter);
 extern u8 rtw_do_join(_adapter *padapter);
 
 
-void rtw_init_mlme_timer(_adapter *padapter)
+static void rtw_init_mlme_timer(_adapter *padapter)
 {
 	struct	mlme_priv *pmlmepriv = &padapter->mlmepriv;
 
@@ -37,7 +37,7 @@ void rtw_init_mlme_timer(_adapter *padapter)
 #endif
 }
 
-sint	_rtw_init_mlme_priv(_adapter *padapter)
+static sint	_rtw_init_mlme_priv(_adapter *padapter)
 {
 	sint	i;
 	u8	*pbuf;
@@ -302,7 +302,7 @@ exit:
 }
 #endif /* defined(CONFIG_WFD) && defined(CONFIG_IOCTL_CFG80211) */
 
-void _rtw_free_mlme_priv(struct mlme_priv *pmlmepriv)
+static void _rtw_free_mlme_priv(struct mlme_priv *pmlmepriv)
 {
 	_adapter *adapter = mlme_to_adapter(pmlmepriv);
 	if (NULL == pmlmepriv) {
@@ -321,7 +321,7 @@ exit:
 	return;
 }
 
-sint	_rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
+static sint	_rtw_enqueue_network(_queue *queue, struct wlan_network *pnetwork)
 {
 	_irqL irqL;
 
@@ -1651,7 +1651,7 @@ static void free_scanqueue(struct	mlme_priv *pmlmepriv)
 
 }
 
-void rtw_reset_rx_info(_adapter *adapter)
+static void rtw_reset_rx_info(_adapter *adapter)
 {
 	struct recv_priv  *precvpriv = &adapter->recvpriv;
 

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -457,7 +457,7 @@ bool rtw_chset_is_ch_non_ocp(RT_CHANNEL_INFO *ch_set, u8 ch)
 	return rtw_chset_is_chbw_non_ocp(ch_set, ch, CHANNEL_WIDTH_20, HAL_PRIME_CHNL_OFFSET_DONT_CARE);
 }
 
-u32 rtw_chset_get_ch_non_ocp_ms(RT_CHANNEL_INFO *ch_set, u8 ch, u8 bw, u8 offset)
+static u32 rtw_chset_get_ch_non_ocp_ms(RT_CHANNEL_INFO *ch_set, u8 ch, u8 bw, u8 offset)
 {
 	int ms = 0;
 	systime current_time;
@@ -1138,7 +1138,7 @@ static void init_mlme_ext_priv_value(_adapter *padapter)
 #endif /* ROKU_PRIVATE */
 }
 
-void init_mlme_ext_timer(_adapter *padapter)
+static void init_mlme_ext_timer(_adapter *padapter)
 {
 	struct	mlme_ext_priv *pmlmeext = &padapter->mlmeextpriv;
 
@@ -1418,7 +1418,7 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 }
 
 #ifdef CONFIG_P2P
-u32 p2p_listen_state_process(_adapter *padapter, unsigned char *da)
+static u32 p2p_listen_state_process(_adapter *padapter, unsigned char *da)
 {
 	bool response = _TRUE;
 
@@ -3269,7 +3269,7 @@ unsigned int OnAtim(_adapter *padapter, union recv_frame *precv_frame)
 	return _SUCCESS;
 }
 
-unsigned int on_action_spct_ch_switch(_adapter *padapter, struct sta_info *psta, u8 *ies, uint ies_len)
+static unsigned int on_action_spct_ch_switch(_adapter *padapter, struct sta_info *psta, u8 *ies, uint ies_len)
 {
 	unsigned int ret = _FAIL;
 	struct mlme_ext_priv *mlmeext = &padapter->mlmeextpriv;
@@ -4316,7 +4316,7 @@ void issue_p2p_GO_request(_adapter *padapter, u8 *raddr)
 }
 
 
-void issue_p2p_GO_response(_adapter *padapter, u8 *raddr, u8 *frame_body, uint len, u8 result)
+static void issue_p2p_GO_response(_adapter *padapter, u8 *raddr, u8 *frame_body, uint len, u8 result)
 {
 	struct p2p_channels *ch_list = &(adapter_to_rfctl(padapter)->channel_list);
 	unsigned char category = RTW_WLAN_CATEGORY_PUBLIC;
@@ -4733,7 +4733,7 @@ void issue_p2p_GO_response(_adapter *padapter, u8 *raddr, u8 *frame_body, uint l
 
 }
 
-void issue_p2p_GO_confirm(_adapter *padapter, u8 *raddr, u8 result)
+static void issue_p2p_GO_confirm(_adapter *padapter, u8 *raddr, u8 result)
 {
 
 	unsigned char category = RTW_WLAN_CATEGORY_PUBLIC;
@@ -5611,7 +5611,7 @@ void issue_p2p_provision_request(_adapter *padapter, u8 *pssid, u8 ussidlen, u8 
 }
 
 
-u8 is_matched_in_profilelist(u8 *peermacaddr, struct profile_info *profileinfo)
+static u8 is_matched_in_profilelist(u8 *peermacaddr, struct profile_info *profileinfo)
 {
 	u8 i, match_result = 0;
 
@@ -5927,7 +5927,7 @@ void issue_probersp_p2p(_adapter *padapter, unsigned char *da)
 
 }
 
-int _issue_probereq_p2p(_adapter *padapter, u8 *da, int wait_ack)
+static int _issue_probereq_p2p(_adapter *padapter, u8 *da, int wait_ack)
 {
 	int ret = _FAIL;
 	struct xmit_frame		*pmgntframe;
@@ -6304,7 +6304,7 @@ exit:
 
 #endif /* CONFIG_P2P */
 
-s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
+static s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
 {
 	_adapter *adapter = rframe->u.hdr.adapter;
 	struct mlme_ext_priv *mlmeext = &(adapter->mlmeextpriv);
@@ -6329,7 +6329,7 @@ s32 rtw_action_public_decache(union recv_frame *rframe, u8 token_offset)
 	return _SUCCESS;
 }
 
-unsigned int on_action_public_p2p(union recv_frame *precv_frame)
+static unsigned int on_action_public_p2p(union recv_frame *precv_frame)
 {
 	_adapter *padapter = precv_frame->u.hdr.adapter;
 	u8 *pframe = precv_frame->u.hdr.rx_data;
@@ -6679,7 +6679,7 @@ exit:
 	return _SUCCESS;
 }
 
-unsigned int on_action_public_vendor(union recv_frame *precv_frame)
+static unsigned int on_action_public_vendor(union recv_frame *precv_frame)
 {
 	unsigned int ret = _FAIL;
 	u8 *pframe = precv_frame->u.hdr.rx_data;
@@ -6709,7 +6709,7 @@ exit:
 	return ret;
 }
 
-unsigned int on_action_public_default(union recv_frame *precv_frame, u8 action)
+static unsigned int on_action_public_default(union recv_frame *precv_frame, u8 action)
 {
 	unsigned int ret = _FAIL;
 	u8 *pframe = precv_frame->u.hdr.rx_data;
@@ -7247,7 +7247,7 @@ unsigned int DoReserved(_adapter *padapter, union recv_frame *precv_frame)
 	return _SUCCESS;
 }
 
-struct xmit_frame *_alloc_mgtxmitframe(struct xmit_priv *pxmitpriv, bool once)
+static struct xmit_frame *_alloc_mgtxmitframe(struct xmit_priv *pxmitpriv, bool once)
 {
 	struct xmit_frame *pmgntframe;
 	struct xmit_buf *pxmitbuf;
@@ -8240,7 +8240,7 @@ void issue_probersp_zeroconf(_adapter *padapter, char *buf, int buf_len)
 }
 #endif
 
-int _issue_probereq(_adapter *padapter, const NDIS_802_11_SSID *pssid, const u8 *da, u8 ch, bool append_wps, int wait_ack)
+static int _issue_probereq(_adapter *padapter, const NDIS_802_11_SSID *pssid, const u8 *da, u8 ch, bool append_wps, int wait_ack)
 {
 	int ret = _FAIL;
 	struct xmit_frame		*pmgntframe;
@@ -10432,7 +10432,7 @@ void issue_action_BSSCoexistPacket(_adapter *padapter)
 }
 
 /* Spatial Multiplexing Powersave (SMPS) action frame */
-int _issue_action_SM_PS(_adapter *padapter ,  unsigned char *raddr , u8 NewMimoPsMode ,  u8 wait_ack)
+static int _issue_action_SM_PS(_adapter *padapter ,  unsigned char *raddr , u8 NewMimoPsMode ,  u8 wait_ack)
 {
 
 	int ret = _FAIL;
@@ -12469,7 +12469,7 @@ When station does not receive any packet in MAX_CONTINUAL_NORXPACKET_COUNT*2 sec
 recipient station will teardown the block ack by issuing DELBA frame.
 
 *********************************************************************/
-void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
+static void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
 {
 	int	i = 0;
 	int ret = _SUCCESS;
@@ -12508,7 +12508,7 @@ void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
 }
 
 
-u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
+static u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
 {
 	u8 ret = _FALSE;
 #ifdef DBG_EXPIRATION_CHK
@@ -12548,7 +12548,7 @@ u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)
 	return ret;
 }
 
-u8 chk_adhoc_peer_is_alive(struct sta_info *psta)
+static u8 chk_adhoc_peer_is_alive(struct sta_info *psta)
 {
 	u8 ret = _TRUE;
 
@@ -13194,7 +13194,7 @@ void addba_timer_hdl(void *ctx)
 }
 
 #ifdef CONFIG_IEEE80211W
-void report_sta_timeout_event(_adapter *padapter, u8 *MacAddr, unsigned short reason)
+static void report_sta_timeout_event(_adapter *padapter, u8 *MacAddr, unsigned short reason)
 {
 	struct cmd_obj *pcmd_obj;
 	u8 *pevtcmd;
@@ -13251,7 +13251,7 @@ void report_sta_timeout_event(_adapter *padapter, u8 *MacAddr, unsigned short re
 	return;
 }
 
-void clnt_sa_query_timeout(_adapter *padapter)
+static void clnt_sa_query_timeout(_adapter *padapter)
 {
 	struct mlme_ext_priv *mlmeext = &(padapter->mlmeextpriv);
 	struct mlme_ext_info *mlmeinfo = &(mlmeext->mlmext_info);
@@ -13844,7 +13844,7 @@ static bool scan_abort_hdl(_adapter *adapter)
 	return ret;
 }
 
-u8 rtw_scan_sparse(_adapter *adapter, struct rtw_ieee80211_channel *ch, u8 ch_num)
+static u8 rtw_scan_sparse(_adapter *adapter, struct rtw_ieee80211_channel *ch, u8 ch_num)
 {
 	/* interval larger than this is treated as backgroud scan */
 #ifndef RTW_SCAN_SPARSE_BG_INTERVAL_MS
@@ -13939,7 +13939,7 @@ u8 rtw_scan_sparse(_adapter *adapter, struct rtw_ieee80211_channel *ch, u8 ch_nu
 }
 
 #ifdef CONFIG_SCAN_BACKOP
-u8 rtw_scan_backop_decision(_adapter *adapter)
+static u8 rtw_scan_backop_decision(_adapter *adapter)
 {
 	struct mlme_ext_priv *mlmeext = &adapter->mlmeextpriv;
 	struct mi_state mstate;
@@ -14362,7 +14362,7 @@ void site_survey(_adapter *padapter, u8 survey_channel, RT_SCAN_TYPE ScanType)
 	return;
 }
 
-void survey_done_set_ch_bw(_adapter *padapter)
+static void survey_done_set_ch_bw(_adapter *padapter)
 {
 	struct mlme_ext_priv *pmlmeext = &padapter->mlmeextpriv;
 	u8 cur_channel = 0;
@@ -14432,7 +14432,7 @@ exit:
  *
  * Returns: 0: no ps announcement is doing. 1: ps announcement is doing
  */
-u8 rtw_ps_annc(_adapter *adapter, bool ps)
+static u8 rtw_ps_annc(_adapter *adapter, bool ps)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	_adapter *iface;
@@ -14521,7 +14521,7 @@ void rtw_back_opch(_adapter *adapter)
 	_exit_critical_mutex(&rfctl->offch_mutex, NULL);
 }
 
-void sitesurvey_set_igi(_adapter *adapter)
+static void sitesurvey_set_igi(_adapter *adapter)
 {
 	struct mlme_ext_priv *mlmeext = &adapter->mlmeextpriv;
 	struct ss_res *ss = &mlmeext->sitesurvey_res;
@@ -14581,7 +14581,7 @@ void sitesurvey_set_igi(_adapter *adapter)
 		break;
 	}
 }
-void sitesurvey_set_msr(_adapter *adapter, bool enter)
+static void sitesurvey_set_msr(_adapter *adapter, bool enter)
 {
 	u8 network_type;
 	struct mlme_ext_priv *pmlmeext = &adapter->mlmeextpriv;

--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -301,7 +301,7 @@ static void PHY_SetRFPathSwitch_default(
 }
 #endif
 
-void mpt_InitHWConfig(PADAPTER Adapter)
+static void mpt_InitHWConfig(PADAPTER Adapter)
 {
 	PHAL_DATA_TYPE hal;
 
@@ -1179,7 +1179,7 @@ int SetTxPower(PADAPTER pAdapter)
 	return _TRUE;
 }
 
-void SetTxAGCOffset(PADAPTER pAdapter, u32 ulTxAGCOffset)
+static void SetTxAGCOffset(PADAPTER pAdapter, u32 ulTxAGCOffset)
 {
 	u32 TxAGCOffset_B, TxAGCOffset_C, TxAGCOffset_D, tmpAGC;
 

--- a/core/rtw_odm.c
+++ b/core/rtw_odm.c
@@ -64,7 +64,7 @@ void rtw_odm_init_ic_type(_adapter *adapter)
 	odm_cmn_info_init(odm, ODM_CMNINFO_IC_TYPE, ic_type);
 }
 
-void rtw_odm_adaptivity_ver_msg(void *sel, _adapter *adapter)
+static void rtw_odm_adaptivity_ver_msg(void *sel, _adapter *adapter)
 {
 	RTW_PRINT_SEL(sel, "ADAPTIVITY_VERSION "ADAPTIVITY_VERSION"\n");
 }
@@ -72,7 +72,7 @@ void rtw_odm_adaptivity_ver_msg(void *sel, _adapter *adapter)
 #define RTW_ADAPTIVITY_EN_DISABLE 0
 #define RTW_ADAPTIVITY_EN_ENABLE 1
 
-void rtw_odm_adaptivity_en_msg(void *sel, _adapter *adapter)
+static void rtw_odm_adaptivity_en_msg(void *sel, _adapter *adapter)
 {
 	struct registry_priv *regsty = &adapter->registrypriv;
 
@@ -89,7 +89,7 @@ void rtw_odm_adaptivity_en_msg(void *sel, _adapter *adapter)
 #define RTW_ADAPTIVITY_MODE_NORMAL 0
 #define RTW_ADAPTIVITY_MODE_CARRIER_SENSE 1
 
-void rtw_odm_adaptivity_mode_msg(void *sel, _adapter *adapter)
+static void rtw_odm_adaptivity_mode_msg(void *sel, _adapter *adapter)
 {
 	struct registry_priv *regsty = &adapter->registrypriv;
 

--- a/core/rtw_p2p.c
+++ b/core/rtw_p2p.c
@@ -18,7 +18,7 @@
 
 #ifdef CONFIG_P2P
 
-int rtw_p2p_is_channel_list_ok(u8 desired_ch, u8 *ch_list, u8 ch_cnt)
+static int rtw_p2p_is_channel_list_ok(u8 desired_ch, u8 *ch_list, u8 ch_cnt)
 {
 	int found = 0, i = 0;
 
@@ -31,7 +31,7 @@ int rtw_p2p_is_channel_list_ok(u8 desired_ch, u8 *ch_list, u8 ch_cnt)
 	return found ;
 }
 
-int is_any_client_associated(_adapter *padapter)
+static int is_any_client_associated(_adapter *padapter)
 {
 	return padapter->stapriv.asoc_list_cnt ? _TRUE : _FALSE;
 }
@@ -2489,7 +2489,7 @@ u8 process_p2p_provdisc_resp(struct wifidirect_info *pwdinfo,  u8 *pframe)
 	return _TRUE;
 }
 
-u8 rtw_p2p_get_peer_ch_list(struct wifidirect_info *pwdinfo, u8 *ch_content, u8 ch_cnt, u8 *peer_ch_list)
+static u8 rtw_p2p_get_peer_ch_list(struct wifidirect_info *pwdinfo, u8 *ch_content, u8 ch_cnt, u8 *peer_ch_list)
 {
 	u8 i = 0, j = 0;
 	u8 temp = 0;
@@ -2511,7 +2511,7 @@ u8 rtw_p2p_get_peer_ch_list(struct wifidirect_info *pwdinfo, u8 *ch_content, u8 
 	return ch_no;
 }
 
-u8 rtw_p2p_ch_inclusion(_adapter *adapter, u8 *peer_ch_list, u8 peer_ch_num, u8 *ch_list_inclusioned)
+static u8 rtw_p2p_ch_inclusion(_adapter *adapter, u8 *peer_ch_list, u8 peer_ch_num, u8 *ch_list_inclusioned)
 {
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
 	int	i = 0, j = 0, temp = 0;
@@ -3006,7 +3006,7 @@ u8 process_p2p_presence_req(struct wifidirect_info *pwdinfo, u8 *pframe, uint le
 	return _TRUE;
 }
 
-void find_phase_handler(_adapter	*padapter)
+static void find_phase_handler(_adapter	*padapter)
 {
 	struct wifidirect_info  *pwdinfo = &padapter->wdinfo;
 	struct mlme_priv		*pmlmepriv = &padapter->mlmepriv;
@@ -3031,7 +3031,7 @@ void find_phase_handler(_adapter	*padapter)
 
 void p2p_concurrent_handler(_adapter *padapter);
 
-void restore_p2p_state_handler(_adapter	*padapter)
+static void restore_p2p_state_handler(_adapter	*padapter)
 {
 	struct wifidirect_info  *pwdinfo = &padapter->wdinfo;
 
@@ -3064,7 +3064,7 @@ void restore_p2p_state_handler(_adapter	*padapter)
 	}
 }
 
-void pre_tx_invitereq_handler(_adapter	*padapter)
+static void pre_tx_invitereq_handler(_adapter	*padapter)
 {
 	struct wifidirect_info  *pwdinfo = &padapter->wdinfo;
 	u8	val8 = 1;
@@ -3076,7 +3076,7 @@ void pre_tx_invitereq_handler(_adapter	*padapter)
 
 }
 
-void pre_tx_provdisc_handler(_adapter	*padapter)
+static void pre_tx_provdisc_handler(_adapter	*padapter)
 {
 	struct wifidirect_info  *pwdinfo = &padapter->wdinfo;
 	u8	val8 = 1;
@@ -3088,7 +3088,7 @@ void pre_tx_provdisc_handler(_adapter	*padapter)
 
 }
 
-void pre_tx_negoreq_handler(_adapter	*padapter)
+static void pre_tx_negoreq_handler(_adapter	*padapter)
 {
 	struct wifidirect_info  *pwdinfo = &padapter->wdinfo;
 	u8	val8 = 1;
@@ -3709,7 +3709,7 @@ static void rtw_cfg80211_adjust_p2pie_channel(_adapter *padapter, const u8 *fram
 #endif
 
 #ifdef CONFIG_WFD
-u32 rtw_xframe_build_wfd_ie(struct xmit_frame *xframe)
+static u32 rtw_xframe_build_wfd_ie(struct xmit_frame *xframe)
 {
 	_adapter *adapter = xframe->padapter;
 	struct wifidirect_info *wdinfo = &adapter->wdinfo;
@@ -3787,7 +3787,7 @@ u32 rtw_xframe_build_wfd_ie(struct xmit_frame *xframe)
 }
 #endif /* CONFIG_WFD */
 
-bool rtw_xframe_del_wfd_ie(struct xmit_frame *xframe)
+static bool rtw_xframe_del_wfd_ie(struct xmit_frame *xframe)
 {
 #define DBG_XFRAME_DEL_WFD_IE 0
 	u8 *frame = xframe->buf_addr + TXDESC_OFFSET;
@@ -3859,7 +3859,7 @@ void rtw_xframe_chk_wfd_ie(struct xmit_frame *xframe)
 #endif
 }
 
-u8 *dump_p2p_attr_ch_list(u8 *p2p_ie, uint p2p_ielen, u8 *buf, u32 buf_len)
+static u8 *dump_p2p_attr_ch_list(u8 *p2p_ie, uint p2p_ielen, u8 *buf, u32 buf_len)
 {
 	uint attr_contentlen = 0;
 	u8 *pattr = NULL;
@@ -3911,7 +3911,7 @@ u8 *dump_p2p_attr_ch_list(u8 *p2p_ie, uint p2p_ielen, u8 *buf, u32 buf_len)
 /*
  * return _TRUE if requester is GO, _FALSE if responder is GO
  */
-bool rtw_p2p_nego_intent_compare(u8 req, u8 resp)
+static bool rtw_p2p_nego_intent_compare(u8 req, u8 resp)
 {
 	if (req >> 1 == resp >> 1)
 		return  req & 0x01 ? _TRUE : _FALSE;

--- a/core/rtw_pwrctrl.c
+++ b/core/rtw_pwrctrl.c
@@ -197,7 +197,7 @@ int ips_leave(_adapter *padapter)
 	int rtw_hw_resume(_adapter *padapter);
 #endif
 
-bool rtw_pwr_unassociated_idle(_adapter *adapter)
+static bool rtw_pwr_unassociated_idle(_adapter *adapter)
 {
 	u8 i;
 	_adapter *iface;
@@ -349,7 +349,7 @@ exit:
 	return;
 }
 
-void pwr_state_check_handler(void *ctx)
+static void pwr_state_check_handler(void *ctx)
 {
 	_adapter *padapter = (_adapter *)ctx;
 	rtw_ps_cmd(padapter);
@@ -639,7 +639,7 @@ u8 rtw_set_rpwm(PADAPTER padapter, u8 pslv)
 	return rpwm;
 }
 
-u8 PS_RDY_CHECK(_adapter *padapter)
+static u8 PS_RDY_CHECK(_adapter *padapter)
 {
 	struct pwrctrl_priv	*pwrpriv = adapter_to_pwrctl(padapter);
 	struct mlme_priv	*pmlmepriv = &(padapter->mlmepriv);

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -915,7 +915,7 @@ sint recv_decache(union recv_frame *precv_frame)
 	return _SUCCESS;
 }
 
-void process_pwrbit_data(_adapter *padapter, union recv_frame *precv_frame, struct sta_info *psta)
+static void process_pwrbit_data(_adapter *padapter, union recv_frame *precv_frame, struct sta_info *psta)
 {
 #ifdef CONFIG_AP_MODE
 	unsigned char pwrbit;
@@ -943,7 +943,7 @@ void process_pwrbit_data(_adapter *padapter, union recv_frame *precv_frame, stru
 #endif
 }
 
-void process_wmmps_data(_adapter *padapter, union recv_frame *precv_frame, struct sta_info *psta)
+static void process_wmmps_data(_adapter *padapter, union recv_frame *precv_frame, struct sta_info *psta)
 {
 #ifdef CONFIG_AP_MODE
 	struct rx_pkt_attrib *pattrib = &precv_frame->u.hdr.attrib;
@@ -1176,7 +1176,7 @@ void count_rx_stats(_adapter *padapter, union recv_frame *prframe, struct sta_in
 
 }
 
-sint sta2sta_data_frame(
+static sint sta2sta_data_frame(
 	_adapter *adapter,
 	union recv_frame *precv_frame,
 	struct sta_info **psta
@@ -1355,7 +1355,7 @@ exit:
 
 }
 
-sint ap2sta_data_frame(
+static sint ap2sta_data_frame(
 	_adapter *adapter,
 	union recv_frame *precv_frame,
 	struct sta_info **psta)
@@ -1495,7 +1495,7 @@ exit:
 
 }
 
-sint sta2ap_data_frame(
+static sint sta2ap_data_frame(
 	_adapter *adapter,
 	union recv_frame *precv_frame,
 	struct sta_info **psta)
@@ -2027,7 +2027,7 @@ exit:
 
 }
 
-sint validate_recv_data_frame(_adapter *adapter, union recv_frame *precv_frame)
+static sint validate_recv_data_frame(_adapter *adapter, union recv_frame *precv_frame)
 {
 	u8 bretry, a4_shift;
 	struct sta_info *psta = NULL;
@@ -2383,7 +2383,7 @@ exit:
 
 
 /* remove the wlanhdr and add the eth_hdr */
-sint wlanhdr_to_ethhdr(union recv_frame *precvframe)
+static sint wlanhdr_to_ethhdr(union recv_frame *precvframe)
 {
 	sint	rmv_len;
 	u16	eth_type, len;
@@ -2892,7 +2892,7 @@ exit:
 }
 #endif /* CONFIG_RTW_MESH */
 
-int amsdu_to_msdu(_adapter *padapter, union recv_frame *prframe)
+static int amsdu_to_msdu(_adapter *padapter, union recv_frame *prframe)
 {
 	struct rx_pkt_attrib *rattrib = &prframe->u.hdr.attrib;
 	int	a_len, padding_len;
@@ -3559,7 +3559,7 @@ static void recv_set_iseq_after_mpdu_process(union recv_frame *rframe, u16 seq_n
 }
 
 #ifdef CONFIG_MP_INCLUDED
-int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
+static int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
 {
 	int ret = _SUCCESS;
 	u8 *ptr = precv_frame->u.hdr.rx_data;
@@ -3718,7 +3718,7 @@ static sint MPwlanhdr_to_ethhdr(union recv_frame *precvframe)
 }
 
 
-int mp_recv_frame(_adapter *padapter, union recv_frame *rframe)
+static int mp_recv_frame(_adapter *padapter, union recv_frame *rframe)
 {
 	int ret = _SUCCESS;
 	struct rx_pkt_attrib *pattrib = &rframe->u.hdr.attrib;
@@ -3849,7 +3849,7 @@ exit:
 
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24))
-int recv_frame_monitor(_adapter *padapter, union recv_frame *rframe)
+static int recv_frame_monitor(_adapter *padapter, union recv_frame *rframe)
 {
 	int ret = _SUCCESS;
 	_queue *pfree_recv_queue = &padapter->recvpriv.free_recv_queue;
@@ -3898,7 +3898,7 @@ exit:
 	return ret;
 }
 #endif
-int recv_func_prehandle(_adapter *padapter, union recv_frame *rframe)
+static int recv_func_prehandle(_adapter *padapter, union recv_frame *rframe)
 {
 	int ret = _SUCCESS;
 #ifdef DBG_RX_COUNTER_DUMP
@@ -3935,7 +3935,7 @@ exit:
 }
 
 /*#define DBG_RX_BMC_FRAME*/
-int recv_func_posthandle(_adapter *padapter, union recv_frame *prframe)
+static int recv_func_posthandle(_adapter *padapter, union recv_frame *prframe)
 {
 	int ret = _SUCCESS;
 	union recv_frame *orig_prframe = prframe;
@@ -4043,7 +4043,7 @@ _recv_data_drop:
 	return ret;
 }
 
-int recv_func(_adapter *padapter, union recv_frame *rframe)
+static int recv_func(_adapter *padapter, union recv_frame *rframe)
 {
 	int ret;
 	struct rx_pkt_attrib *prxattrib = &rframe->u.hdr.attrib;
@@ -4365,7 +4365,7 @@ static void rx_process_link_qual(_adapter *padapter, union recv_frame *prframe)
 #endif /* CONFIG_NEW_SIGNAL_STAT_PROCESS */
 }
 
-void rx_process_phy_info(_adapter *padapter, union recv_frame *rframe)
+static void rx_process_phy_info(_adapter *padapter, union recv_frame *rframe)
 {
 	/* Check RSSI */
 	rx_process_rssi(padapter, rframe);

--- a/core/rtw_rf.c
+++ b/core/rtw_rf.c
@@ -850,7 +850,7 @@ s16 mb_of_ntx(u8 ntx)
 }
 
 #if CONFIG_TXPWR_LIMIT
-void _dump_regd_exc_list(void *sel, struct rf_ctl_t *rfctl)
+static void _dump_regd_exc_list(void *sel, struct rf_ctl_t *rfctl)
 {
 	struct regd_exc_ent *ent;
 	_list *cur, *head;
@@ -1452,7 +1452,7 @@ int rtw_ch_to_bb_gain_sel(int ch)
 	return sel;
 }
 
-s8 rtw_rf_get_kfree_tx_gain_offset(_adapter *padapter, u8 path, u8 ch)
+static s8 rtw_rf_get_kfree_tx_gain_offset(_adapter *padapter, u8 path, u8 ch)
 {
 	s8 kfree_offset = 0;
 

--- a/core/rtw_sreset.c
+++ b/core/rtw_sreset.c
@@ -101,7 +101,7 @@ bool sreset_inprogress(_adapter *padapter)
 #endif
 }
 
-void sreset_restore_security_station(_adapter *padapter)
+static void sreset_restore_security_station(_adapter *padapter)
 {
 	struct mlme_priv *mlmepriv = &padapter->mlmepriv;
 	struct sta_priv *pstapriv = &padapter->stapriv;
@@ -137,7 +137,7 @@ void sreset_restore_security_station(_adapter *padapter)
 	}
 }
 
-void sreset_restore_network_station(_adapter *padapter)
+static void sreset_restore_network_station(_adapter *padapter)
 {
 	struct mlme_priv *mlmepriv = &padapter->mlmepriv;
 	struct mlme_ext_priv	*pmlmeext = &padapter->mlmeextpriv;
@@ -197,7 +197,7 @@ void sreset_restore_network_station(_adapter *padapter)
 }
 
 
-void sreset_restore_network_status(_adapter *padapter)
+static void sreset_restore_network_status(_adapter *padapter)
 {
 	struct mlme_priv *mlmepriv = &padapter->mlmepriv;
 

--- a/core/rtw_sta_mgt.c
+++ b/core/rtw_sta_mgt.c
@@ -16,7 +16,7 @@
 
 #include <drv_types.h>
 
-bool test_st_match_rule(_adapter *adapter, u8 *local_naddr, u8 *local_port, u8 *remote_naddr, u8 *remote_port)
+static bool test_st_match_rule(_adapter *adapter, u8 *local_naddr, u8 *local_port, u8 *remote_naddr, u8 *remote_port)
 {
 	if (ntohs(*((u16 *)local_port)) == 5001 || ntohs(*((u16 *)remote_port)) == 5001)
 		return _TRUE;
@@ -1076,7 +1076,7 @@ const char *const _acl_mode_str[RTW_ACL_MODE_MAX] = {
 	"DENY_UNLESS_LISTED",
 };
 
-u8 _rtw_access_ctrl(_adapter *adapter, u8 period, const u8 *mac_addr)
+static u8 _rtw_access_ctrl(_adapter *adapter, u8 period, const u8 *mac_addr)
 {
 	u8 res = _TRUE;
 	_irqL irqL;

--- a/core/rtw_vht.c
+++ b/core/rtw_vht.c
@@ -39,7 +39,7 @@ const char *const _vht_sup_ch_width_set_str[] = {
 	"BW-RSVD",
 };
 
-void dump_vht_cap_ie_content(void *sel, const u8 *buf, u32 buf_len)
+static void dump_vht_cap_ie_content(void *sel, const u8 *buf, u32 buf_len)
 {
 	if (buf_len != VHT_CAP_IE_LEN) {
 		RTW_PRINT_SEL(sel, "Invalid VHT capability IE len:%d != %d\n", buf_len, VHT_CAP_IE_LEN);
@@ -79,7 +79,7 @@ const char *const _vht_op_ch_width_str[] = {
 	"BW-RSVD",
 };
 
-void dump_vht_op_ie_content(void *sel, const u8 *buf, u32 buf_len)
+static void dump_vht_op_ie_content(void *sel, const u8 *buf, u32 buf_len)
 {
 	if (buf_len != VHT_OP_IE_LEN) {
 		RTW_PRINT_SEL(sel, "Invalid VHT operation IE len:%d != %d\n", buf_len, VHT_OP_IE_LEN);
@@ -356,7 +356,7 @@ u64	rtw_vht_mcs_map_to_bitmap(u8 *mcs_map, u8 nss)
 }
 
 #ifdef CONFIG_BEAMFORMING
-void update_sta_vht_info_apmode_bf_cap(_adapter *padapter, struct sta_info *psta)
+static void update_sta_vht_info_apmode_bf_cap(_adapter *padapter, struct sta_info *psta)
 {
 	struct mlme_priv	*pmlmepriv = &(padapter->mlmepriv);
 	struct vht_priv	*pvhtpriv_ap = &pmlmepriv->vhtpriv;

--- a/core/rtw_wlan_util.c
+++ b/core/rtw_wlan_util.c
@@ -1042,7 +1042,7 @@ inline bool rtw_sec_camid_is_drv_forbid(struct cam_ctl_t *cam_ctl, u8 id)
 	return 1;
 }
 
-bool _rtw_sec_camid_is_used(struct cam_ctl_t *cam_ctl, u8 id)
+static bool _rtw_sec_camid_is_used(struct cam_ctl_t *cam_ctl, u8 id)
 {
 	bool ret = _FALSE;
 
@@ -1130,7 +1130,7 @@ inline bool rtw_camid_is_gk(_adapter *adapter, u8 cam_id)
 	return ret;
 }
 
-bool cam_cache_chk(_adapter *adapter, u8 id, u8 *addr, s16 kid, s8 gk)
+static bool cam_cache_chk(_adapter *adapter, u8 id, u8 *addr, s16 kid, s8 gk)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	bool ret = _FALSE;
@@ -1148,7 +1148,7 @@ exit:
 	return ret;
 }
 
-s16 _rtw_camid_search(_adapter *adapter, u8 *addr, s16 kid, s8 gk)
+static s16 _rtw_camid_search(_adapter *adapter, u8 *addr, s16 kid, s8 gk)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct cam_ctl_t *cam_ctl = &dvobj->cam_ctl;
@@ -1188,7 +1188,7 @@ s16 rtw_camid_search(_adapter *adapter, u8 *addr, s16 kid, s8 gk)
 	return cam_id;
 }
 
-s16 rtw_get_camid(_adapter *adapter, u8 *addr, s16 kid, u8 gk, bool ext_sec)
+static s16 rtw_get_camid(_adapter *adapter, u8 *addr, s16 kid, u8 gk, bool ext_sec)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct cam_ctl_t *cam_ctl = &dvobj->cam_ctl;
@@ -1318,7 +1318,7 @@ bitmap_handle:
 	return cam_id;
 }
 
-void rtw_camid_set(_adapter *adapter, u8 cam_id)
+static void rtw_camid_set(_adapter *adapter, u8 cam_id)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct cam_ctl_t *cam_ctl = &dvobj->cam_ctl;
@@ -1399,7 +1399,7 @@ inline void rtw_sec_cam_swap(_adapter *adapter, u8 cam_id_a, u8 cam_id_b)
 	}
 }
 
-s16 rtw_get_empty_cam_entry(_adapter *adapter, u8 start_camid)
+static s16 rtw_get_empty_cam_entry(_adapter *adapter, u8 start_camid)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct cam_ctl_t *cam_ctl = &dvobj->cam_ctl;
@@ -2284,7 +2284,7 @@ void	update_ldpc_stbc_cap(struct sta_info *psta)
 #endif /* CONFIG_80211N_HT */
 }
 
-int check_ielen(u8 *start, uint len)
+static int check_ielen(u8 *start, uint len)
 {
 	int left = len;
 	u8 *pos = start;
@@ -2508,7 +2508,7 @@ void rtw_debug_rx_bcn(_adapter *adapter, u8 *pframe, u32 packet_len)
  *	WLAN_EID_CHANNEL_SWITCH
  *	WLAN_EID_PWR_CONSTRAINT
  */
-int _rtw_get_bcn_keys(u8 *cap_info, u32 buf_len, u8 def_ch, ADAPTER *adapter
+static int _rtw_get_bcn_keys(u8 *cap_info, u32 buf_len, u8 def_ch, ADAPTER *adapter
 	, struct beacon_keys *recv_beacon)
 {
 	int left;

--- a/core/rtw_xmit.c
+++ b/core/rtw_xmit.c
@@ -57,7 +57,7 @@ void rtw_init_xmit_block(_adapter *padapter)
 	dvobj->xmit_block = XMIT_BLOCK_NONE;
 
 }
-void rtw_free_xmit_block(_adapter *padapter)
+static void rtw_free_xmit_block(_adapter *padapter)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(padapter);
 
@@ -462,7 +462,7 @@ u8 rtw_get_tx_bw_mode(_adapter *adapter, struct sta_info *sta)
 	return bw;
 }
 
-void rtw_get_adapter_tx_rate_bmp_by_bw(_adapter *adapter, u8 bw, u16 *r_bmp_cck_ofdm, u32 *r_bmp_ht, u64 *r_bmp_vht)
+static void rtw_get_adapter_tx_rate_bmp_by_bw(_adapter *adapter, u8 bw, u16 *r_bmp_cck_ofdm, u32 *r_bmp_ht, u64 *r_bmp_vht)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	struct macid_ctl_t *macid_ctl = dvobj_to_macidctl(dvobj);
@@ -506,7 +506,7 @@ void rtw_get_adapter_tx_rate_bmp_by_bw(_adapter *adapter, u8 bw, u16 *r_bmp_cck_
 		*r_bmp_vht = bmp_vht;
 }
 
-void rtw_get_shared_macid_tx_rate_bmp_by_bw(struct dvobj_priv *dvobj, u8 bw, u16 *r_bmp_cck_ofdm, u32 *r_bmp_ht, u64 *r_bmp_vht)
+static void rtw_get_shared_macid_tx_rate_bmp_by_bw(struct dvobj_priv *dvobj, u8 bw, u16 *r_bmp_cck_ofdm, u32 *r_bmp_ht, u64 *r_bmp_vht)
 {
 	struct macid_ctl_t *macid_ctl = dvobj_to_macidctl(dvobj);
 	u16 bmp_cck_ofdm = 0;
@@ -541,7 +541,7 @@ void rtw_get_shared_macid_tx_rate_bmp_by_bw(struct dvobj_priv *dvobj, u8 bw, u16
 		*r_bmp_vht = bmp_vht;
 }
 
-void rtw_get_adapter_tx_rate_bmp(_adapter *adapter, u16 r_bmp_cck_ofdm[], u32 r_bmp_ht[], u64 r_bmp_vht[])
+static void rtw_get_adapter_tx_rate_bmp(_adapter *adapter, u16 r_bmp_cck_ofdm[], u32 r_bmp_ht[], u64 r_bmp_vht[])
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	u8 bw;
@@ -3692,7 +3692,7 @@ s32 rtw_free_xmitbuf(struct xmit_priv *pxmitpriv, struct xmit_buf *pxmitbuf)
 	return _SUCCESS;
 }
 
-void rtw_init_xmitframe(struct xmit_frame *pxframe)
+static void rtw_init_xmitframe(struct xmit_frame *pxframe)
 {
 	if (pxframe !=  NULL) { /* default value setting */
 		pxframe->buf_addr = NULL;
@@ -4366,7 +4366,7 @@ void rtw_init_hwxmits(struct hw_xmit *phwxmit, sint entry)
 }
 
 #ifdef CONFIG_BR_EXT
-int rtw_br_client_tx(_adapter *padapter, struct sk_buff **pskb)
+static int rtw_br_client_tx(_adapter *padapter, struct sk_buff **pskb)
 {
 	struct sk_buff *skb = *pskb;
 	_irqL irqL;
@@ -6228,7 +6228,7 @@ int rtw_sctx_wait(struct submit_ctx *sctx, const char *msg)
 	return ret;
 }
 
-bool rtw_sctx_chk_waring_status(int status)
+static bool rtw_sctx_chk_waring_status(int status)
 {
 	switch (status) {
 	case RTW_SCTX_DONE_UNKNOWN:

--- a/hal/btc/halbtc8822c.c
+++ b/hal/btc/halbtc8822c.c
@@ -240,7 +240,7 @@ void halbtc8822c_cfg_init(struct btc_coexist *btc)
 void halbtc8822c_cfg_ant_switch(struct btc_coexist *btc)
 {}
 
-void halbtc8822c_cfg_gnt_fix(struct btc_coexist *btc)
+static void halbtc8822c_cfg_gnt_fix(struct btc_coexist *btc)
 {
 	struct btc_coex_sta *coex_sta = &btc->coex_sta;
 	struct btc_wifi_link_info_ext *link_info_ext = &btc->wifi_link_info_ext;
@@ -324,7 +324,7 @@ void halbtc8822c_cfg_gnt_debug(struct btc_coexist *btc)
 	/* btc->btc_write_1byte_bitmask(btc, 0x73, BIT(3), 0); */
 }
 
-void halbtc8822c_cfg_rfe_type(struct btc_coexist *btc)
+static void halbtc8822c_cfg_rfe_type(struct btc_coexist *btc)
 {
 	struct btc_coex_sta *coex_sta = &btc->coex_sta;
 	struct btc_rfe_type *rfe_type = &btc->rfe_type;

--- a/hal/btc/halbtccommon.c
+++ b/hal/btc/halbtccommon.c
@@ -2029,7 +2029,7 @@ static void rtw_btc_action_ext_chip(struct btc_coexist *btc)
 		rtw_btc_action_rf4ce(btc);
 }
 
-u8 rtw_btc_action_rf4ce_new_tdma(struct btc_coexist *btc, u8 type)
+static u8 rtw_btc_action_rf4ce_new_tdma(struct btc_coexist *btc, u8 type)
 {
 	struct btc_coex_sta *coex_sta = &btc->coex_sta;
 	const struct btc_chip_para *chip_para = btc->chip_para;
@@ -2082,7 +2082,7 @@ u8 rtw_btc_action_rf4ce_new_tdma(struct btc_coexist *btc, u8 type)
 	return tdma_case;
 }
 
-u8 rtw_btc_ext_chip_new_tdma(struct btc_coexist *btc, u8 type)
+static u8 rtw_btc_ext_chip_new_tdma(struct btc_coexist *btc, u8 type)
 {
 	struct btc_coex_sta *coex_sta = &btc->coex_sta;
 	u8 tdma_case = 0;

--- a/hal/hal_btcoex.c
+++ b/hal/hal_btcoex.c
@@ -311,7 +311,7 @@ static u8 halbtcoutsrc_LeaveLps(PBTC_COEXIST pBtCoexist)
 	return rtw_btcoex_LPS_Leave(padapter);
 }
 
-void halbtcoutsrc_EnterLps(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_EnterLps(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 
@@ -326,7 +326,7 @@ void halbtcoutsrc_EnterLps(PBTC_COEXIST pBtCoexist)
 	}
 }
 
-void halbtcoutsrc_NormalLps(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_NormalLps(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 
@@ -349,7 +349,7 @@ void halbtcoutsrc_NormalLps(PBTC_COEXIST pBtCoexist)
 	}
 }
 
-void halbtcoutsrc_Pre_NormalLps(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_Pre_NormalLps(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 
@@ -361,7 +361,7 @@ void halbtcoutsrc_Pre_NormalLps(PBTC_COEXIST pBtCoexist)
 	}
 }
 
-void halbtcoutsrc_Post_NormalLps(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_Post_NormalLps(PBTC_COEXIST pBtCoexist)
 {
 	if (pBtCoexist->bt_info.bt_ctrl_lps)
 		pBtCoexist->bt_info.bt_ctrl_lps = _FALSE;
@@ -371,7 +371,7 @@ void halbtcoutsrc_Post_NormalLps(PBTC_COEXIST pBtCoexist)
  *  Constraint:
  *	   1. this function will request pwrctrl->lock
  */
-void halbtcoutsrc_LeaveLowPower(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_LeaveLowPower(PBTC_COEXIST pBtCoexist)
 {
 #ifdef CONFIG_LPS_LCLK
 	PADAPTER padapter;
@@ -417,7 +417,7 @@ void halbtcoutsrc_LeaveLowPower(PBTC_COEXIST pBtCoexist)
  *  Constraint:
  *	   1. this function will request pwrctrl->lock
  */
-void halbtcoutsrc_NormalLowPower(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_NormalLowPower(PBTC_COEXIST pBtCoexist)
 {
 #ifdef CONFIG_LPS_LCLK
 	PADAPTER padapter;
@@ -432,7 +432,7 @@ void halbtcoutsrc_NormalLowPower(PBTC_COEXIST pBtCoexist)
 #endif /* CONFIG_LPS_LCLK */
 }
 
-void halbtcoutsrc_DisableLowPower(PBTC_COEXIST pBtCoexist, u8 bLowPwrDisable)
+static void halbtcoutsrc_DisableLowPower(PBTC_COEXIST pBtCoexist, u8 bLowPwrDisable)
 {
 	pBtCoexist->bt_info.bt_disable_low_pwr = bLowPwrDisable;
 	if (bLowPwrDisable)
@@ -441,7 +441,7 @@ void halbtcoutsrc_DisableLowPower(PBTC_COEXIST pBtCoexist, u8 bLowPwrDisable)
 		halbtcoutsrc_NormalLowPower(pBtCoexist);	/* original 32k low power behavior. */
 }
 
-void halbtcoutsrc_AggregationCheck(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_AggregationCheck(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 	BOOLEAN bNeedToAct = _FALSE;
@@ -489,7 +489,7 @@ void halbtcoutsrc_AggregationCheck(PBTC_COEXIST pBtCoexist)
 		rtw_btcoex_rx_ampdu_apply(padapter);
 }
 
-u8 halbtcoutsrc_is_autoload_fail(PBTC_COEXIST pBtCoexist)
+static u8 halbtcoutsrc_is_autoload_fail(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 	PHAL_DATA_TYPE pHalData;
@@ -500,7 +500,7 @@ u8 halbtcoutsrc_is_autoload_fail(PBTC_COEXIST pBtCoexist)
 	return pHalData->bautoload_fail_flag;
 }
 
-u8 halbtcoutsrc_is_fw_ready(PBTC_COEXIST pBtCoexist)
+static u8 halbtcoutsrc_is_fw_ready(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 
@@ -509,7 +509,7 @@ u8 halbtcoutsrc_is_fw_ready(PBTC_COEXIST pBtCoexist)
 	return GET_HAL_DATA(padapter)->bFWReady;
 }
 
-u8 halbtcoutsrc_IsDualBandConnected(PADAPTER padapter)
+static u8 halbtcoutsrc_IsDualBandConnected(PADAPTER padapter)
 {
 	u8 ret = BTC_MULTIPORT_SCC;
 
@@ -530,7 +530,7 @@ u8 halbtcoutsrc_IsDualBandConnected(PADAPTER padapter)
 	return ret;
 }
 
-u8 halbtcoutsrc_IsWifiBusy(PADAPTER padapter)
+static u8 halbtcoutsrc_IsWifiBusy(PADAPTER padapter)
 {
 	if (rtw_mi_check_status(padapter, MI_AP_ASSOC))
 		return _TRUE;
@@ -573,7 +573,7 @@ static u32 _halbtcoutsrc_GetWifiLinkStatus(PADAPTER padapter)
 	return portConnectedStatus;
 }
 
-u32 halbtcoutsrc_GetWifiLinkStatus(PBTC_COEXIST pBtCoexist)
+static u32 halbtcoutsrc_GetWifiLinkStatus(PBTC_COEXIST pBtCoexist)
 {
 	/* ================================= */
 	/* return value: */
@@ -609,7 +609,7 @@ u32 halbtcoutsrc_GetWifiLinkStatus(PBTC_COEXIST pBtCoexist)
 	return retVal;
 }
 
-struct btc_wifi_link_info halbtcoutsrc_getwifilinkinfo(PBTC_COEXIST pBtCoexist)
+static struct btc_wifi_link_info halbtcoutsrc_getwifilinkinfo(PBTC_COEXIST pBtCoexist)
 {
 	u8 n_assoc_iface = 0, i =0, mcc_en = _FALSE;
 	PADAPTER adapter = NULL;
@@ -856,7 +856,7 @@ exit:
 	return ret;
 }
 
-u32 halbtcoutsrc_GetBtPatchVer(PBTC_COEXIST pBtCoexist)
+static u32 halbtcoutsrc_GetBtPatchVer(PBTC_COEXIST pBtCoexist)
 {
 	if (pBtCoexist->bt_info.get_bt_fw_ver_cnt <= 5) {
 		if (halbtcoutsrc_IsHwMailboxExist(pBtCoexist) == _TRUE) {
@@ -887,12 +887,12 @@ u32 halbtcoutsrc_GetBtPatchVer(PBTC_COEXIST pBtCoexist)
 	return pBtCoexist->bt_info.bt_real_fw_ver;
 }
 
-s32 halbtcoutsrc_GetWifiRssi(PADAPTER padapter)
+static s32 halbtcoutsrc_GetWifiRssi(PADAPTER padapter)
 {
 	return rtw_dm_get_min_rssi(padapter);
 }
 
-u32 halbtcoutsrc_GetBtCoexSupportedFeature(void *pBtcContext)
+static u32 halbtcoutsrc_GetBtCoexSupportedFeature(void *pBtcContext)
 {
 	PBTC_COEXIST pBtCoexist;
 	u32 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -923,7 +923,7 @@ u32 halbtcoutsrc_GetBtCoexSupportedFeature(void *pBtcContext)
 	return data;
 }
 
-u32 halbtcoutsrc_GetBtCoexSupportedVersion(void *pBtcContext)
+static u32 halbtcoutsrc_GetBtCoexSupportedVersion(void *pBtcContext)
 {
 	PBTC_COEXIST pBtCoexist;
 	u32 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -954,7 +954,7 @@ u32 halbtcoutsrc_GetBtCoexSupportedVersion(void *pBtcContext)
 	return data;
 }
 
-u32 halbtcoutsrc_GetBtDeviceInfo(void *pBtcContext)
+static u32 halbtcoutsrc_GetBtDeviceInfo(void *pBtcContext)
 {
 	PBTC_COEXIST pBtCoexist;
 	u32 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -985,7 +985,7 @@ u32 halbtcoutsrc_GetBtDeviceInfo(void *pBtcContext)
 	return btDeviceInfo;
 }
 
-u32 halbtcoutsrc_GetBtForbiddenSlotVal(void *pBtcContext)
+static u32 halbtcoutsrc_GetBtForbiddenSlotVal(void *pBtcContext)
 {
 	PBTC_COEXIST pBtCoexist;
 	u32 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -1036,7 +1036,7 @@ static u8 halbtcoutsrc_GetWifiScanAPNum(PADAPTER padapter)
 	return scan_AP_num;
 }
 
-u32 halbtcoutsrc_GetPhydmVersion(void *pBtcContext)
+static u32 halbtcoutsrc_GetPhydmVersion(void *pBtcContext)
 {
 	struct btc_coexist *pBtCoexist = (struct btc_coexist *)pBtcContext;
 	PADAPTER		Adapter = pBtCoexist->Adapter;
@@ -1090,7 +1090,7 @@ u32 halbtcoutsrc_GetPhydmVersion(void *pBtcContext)
 #endif
 }
 
-u8 halbtcoutsrc_Get(void *pBtcContext, u8 getType, void *pOutBuf)
+static u8 halbtcoutsrc_Get(void *pBtcContext, u8 getType, void *pOutBuf)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1405,7 +1405,7 @@ u8 halbtcoutsrc_Get(void *pBtcContext, u8 getType, void *pOutBuf)
 	return ret;
 }
 
-u16 halbtcoutsrc_LnaConstrainLvl(void *pBtcContext, u8 *lna_constrain_level)
+static u16 halbtcoutsrc_LnaConstrainLvl(void *pBtcContext, u8 *lna_constrain_level)
 {
 	PBTC_COEXIST pBtCoexist;
 	u16 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -1429,14 +1429,14 @@ u16 halbtcoutsrc_LnaConstrainLvl(void *pBtcContext, u8 *lna_constrain_level)
 	return ret;
 }
 
-u8 halbtcoutsrc_SetBtGoldenRxRange(void *pBtcContext, u8 profile, u8 range_shift)
+static u8 halbtcoutsrc_SetBtGoldenRxRange(void *pBtcContext, u8 profile, u8 range_shift)
 {
 	/* wait for implementation if necessary */
 
 	return 0;
 }
 
-u8 halbtcoutsrc_Set(void *pBtcContext, u8 setType, void *pInBuf)
+static u8 halbtcoutsrc_Set(void *pBtcContext, u8 setType, void *pInBuf)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -1684,7 +1684,7 @@ u8 halbtcoutsrc_Set(void *pBtcContext, u8 setType, void *pInBuf)
 	return result;
 }
 
-u8 halbtcoutsrc_UnderIps(PBTC_COEXIST pBtCoexist)
+static u8 halbtcoutsrc_UnderIps(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER padapter;
 	struct pwrctrl_priv *pwrpriv;
@@ -1709,18 +1709,18 @@ u8 halbtcoutsrc_UnderIps(PBTC_COEXIST pBtCoexist)
 	return _FALSE;
 }
 
-u8 halbtcoutsrc_UnderLps(PBTC_COEXIST pBtCoexist)
+static u8 halbtcoutsrc_UnderLps(PBTC_COEXIST pBtCoexist)
 {
 	return GLBtcWiFiInLPS;
 }
 
-u8 halbtcoutsrc_Under32K(PBTC_COEXIST pBtCoexist)
+static u8 halbtcoutsrc_Under32K(PBTC_COEXIST pBtCoexist)
 {
 	/* todo: the method to check whether wifi is under 32K or not */
 	return _FALSE;
 }
 
-void halbtcoutsrc_DisplayCoexStatistics(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_DisplayCoexStatistics(PBTC_COEXIST pBtCoexist)
 {
 #if 0
 	PADAPTER padapter = (PADAPTER)pBtCoexist->Adapter;
@@ -1886,7 +1886,7 @@ void halbtcoutsrc_DisplayCoexStatistics(PBTC_COEXIST pBtCoexist)
 	}
 }
 
-void halbtcoutsrc_DisplayBtLinkInfo(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_DisplayBtLinkInfo(PBTC_COEXIST pBtCoexist)
 {
 #if 0
 	PADAPTER padapter = (PADAPTER)pBtCoexist->Adapter;
@@ -1914,7 +1914,7 @@ void halbtcoutsrc_DisplayBtLinkInfo(PBTC_COEXIST pBtCoexist)
 #endif
 }
 
-void halbtcoutsrc_DisplayWifiStatus(PBTC_COEXIST pBtCoexist)
+static void halbtcoutsrc_DisplayWifiStatus(PBTC_COEXIST pBtCoexist)
 {
 	PADAPTER	padapter = pBtCoexist->Adapter;
 	struct pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
@@ -2080,7 +2080,7 @@ void halbtcoutsrc_DisplayWifiStatus(PBTC_COEXIST pBtCoexist)
 	CL_PRINTF(cliBuf);
 }
 
-void halbtcoutsrc_DisplayDbgMsg(void *pBtcContext, u8 dispType)
+static void halbtcoutsrc_DisplayDbgMsg(void *pBtcContext, u8 dispType)
 {
 	PBTC_COEXIST pBtCoexist;
 
@@ -2104,7 +2104,7 @@ void halbtcoutsrc_DisplayDbgMsg(void *pBtcContext, u8 dispType)
 /* ************************************
  *		IO related function
  * ************************************ */
-u8 halbtcoutsrc_Read1Byte(void *pBtcContext, u32 RegAddr)
+static u8 halbtcoutsrc_Read1Byte(void *pBtcContext, u32 RegAddr)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2116,7 +2116,7 @@ u8 halbtcoutsrc_Read1Byte(void *pBtcContext, u32 RegAddr)
 	return rtw_read8(padapter, RegAddr);
 }
 
-u16 halbtcoutsrc_Read2Byte(void *pBtcContext, u32 RegAddr)
+static u16 halbtcoutsrc_Read2Byte(void *pBtcContext, u32 RegAddr)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2128,7 +2128,7 @@ u16 halbtcoutsrc_Read2Byte(void *pBtcContext, u32 RegAddr)
 	return	rtw_read16(padapter, RegAddr);
 }
 
-u32 halbtcoutsrc_Read4Byte(void *pBtcContext, u32 RegAddr)
+static u32 halbtcoutsrc_Read4Byte(void *pBtcContext, u32 RegAddr)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2140,7 +2140,7 @@ u32 halbtcoutsrc_Read4Byte(void *pBtcContext, u32 RegAddr)
 	return	rtw_read32(padapter, RegAddr);
 }
 
-void halbtcoutsrc_Write1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
+static void halbtcoutsrc_Write1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2152,7 +2152,7 @@ void halbtcoutsrc_Write1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
 	rtw_write8(padapter, RegAddr, Data);
 }
 
-void halbtcoutsrc_BitMaskWrite1Byte(void *pBtcContext, u32 regAddr, u8 bitMask, u8 data1b)
+static void halbtcoutsrc_BitMaskWrite1Byte(void *pBtcContext, u32 regAddr, u8 bitMask, u8 data1b)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2180,7 +2180,7 @@ void halbtcoutsrc_BitMaskWrite1Byte(void *pBtcContext, u32 regAddr, u8 bitMask, 
 	rtw_write8(padapter, regAddr, data1b);
 }
 
-void halbtcoutsrc_Write2Byte(void *pBtcContext, u32 RegAddr, u16 Data)
+static void halbtcoutsrc_Write2Byte(void *pBtcContext, u32 RegAddr, u16 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2192,7 +2192,7 @@ void halbtcoutsrc_Write2Byte(void *pBtcContext, u32 RegAddr, u16 Data)
 	rtw_write16(padapter, RegAddr, Data);
 }
 
-void halbtcoutsrc_Write4Byte(void *pBtcContext, u32 RegAddr, u32 Data)
+static void halbtcoutsrc_Write4Byte(void *pBtcContext, u32 RegAddr, u32 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2204,7 +2204,7 @@ void halbtcoutsrc_Write4Byte(void *pBtcContext, u32 RegAddr, u32 Data)
 	rtw_write32(padapter, RegAddr, Data);
 }
 
-void halbtcoutsrc_WriteLocalReg1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
+static void halbtcoutsrc_WriteLocalReg1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
 {
 	PBTC_COEXIST		pBtCoexist = (PBTC_COEXIST)pBtcContext;
 	PADAPTER			Adapter = pBtCoexist->Adapter;
@@ -2215,7 +2215,7 @@ void halbtcoutsrc_WriteLocalReg1Byte(void *pBtcContext, u32 RegAddr, u8 Data)
 		rtw_write8(Adapter, RegAddr, Data);
 }
 
-u32 halbtcoutsrc_WaitLIndirectReg_Ready(void *pBtcContext)
+static u32 halbtcoutsrc_WaitLIndirectReg_Ready(void *pBtcContext)
 {
 	PBTC_COEXIST btc = (PBTC_COEXIST)pBtcContext;
 	u32 delay_count = 0, reg = 0;
@@ -2248,7 +2248,7 @@ u32 halbtcoutsrc_WaitLIndirectReg_Ready(void *pBtcContext)
 	return delay_count;
 }
 
-u32 halbtcoutsrc_ReadLIndirectReg(void *pBtcContext, u16 reg_addr)
+static u32 halbtcoutsrc_ReadLIndirectReg(void *pBtcContext, u16 reg_addr)
 {
 	PBTC_COEXIST btc = (PBTC_COEXIST)pBtcContext;
 	u32 val = 0;
@@ -2273,7 +2273,7 @@ u32 halbtcoutsrc_ReadLIndirectReg(void *pBtcContext, u16 reg_addr)
 	return val;
 }
 
-void halbtcoutsrc_WriteLIndirectReg(void *pBtcContext, u16 reg_addr, u32 bit_mask, u32 reg_value)
+static void halbtcoutsrc_WriteLIndirectReg(void *pBtcContext, u16 reg_addr, u32 bit_mask, u32 reg_value)
 {
 	PBTC_COEXIST btc = (PBTC_COEXIST)pBtcContext;
 	u32 val, i = 0, bitpos = 0, reg0, reg1;
@@ -2324,7 +2324,7 @@ void halbtcoutsrc_WriteLIndirectReg(void *pBtcContext, u16 reg_addr, u32 bit_mas
 	}
 }
 
-u16 halbtcoutsrc_Read_scbd(void *pBtcContext, u16* score_board_val)
+static u16 halbtcoutsrc_Read_scbd(void *pBtcContext, u16* score_board_val)
 {
 	PBTC_COEXIST btc = (PBTC_COEXIST)pBtcContext;
 	struct btc_coex_sta *coex_sta = &btc->coex_sta;
@@ -2339,7 +2339,7 @@ u16 halbtcoutsrc_Read_scbd(void *pBtcContext, u16* score_board_val)
 	return coex_sta->score_board_BW;
 }
 
-void halbtcoutsrc_Write_scbd(void *pBtcContext, u16 bitpos, u8 state)
+static void halbtcoutsrc_Write_scbd(void *pBtcContext, u16 bitpos, u8 state)
 {
 	PBTC_COEXIST btc = (PBTC_COEXIST)pBtcContext;
 	struct btc_coex_sta *coex_sta = &btc->coex_sta;
@@ -2382,7 +2382,7 @@ void halbtcoutsrc_Write_scbd(void *pBtcContext, u16 bitpos, u8 state)
 	BTC_TRACE(btc_dbg_buf);
 }
 
-void halbtcoutsrc_SetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask, u32 Data)
+static void halbtcoutsrc_SetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask, u32 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2395,7 +2395,7 @@ void halbtcoutsrc_SetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask, u32 Data
 }
 
 
-u32 halbtcoutsrc_GetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask)
+static u32 halbtcoutsrc_GetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2407,7 +2407,7 @@ u32 halbtcoutsrc_GetBbReg(void *pBtcContext, u32 RegAddr, u32 BitMask)
 	return phy_query_bb_reg(padapter, RegAddr, BitMask);
 }
 
-void halbtcoutsrc_SetRfReg(void *pBtcContext, enum rf_path eRFPath, u32 RegAddr, u32 BitMask, u32 Data)
+static void halbtcoutsrc_SetRfReg(void *pBtcContext, enum rf_path eRFPath, u32 RegAddr, u32 BitMask, u32 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2419,7 +2419,7 @@ void halbtcoutsrc_SetRfReg(void *pBtcContext, enum rf_path eRFPath, u32 RegAddr,
 	phy_set_rf_reg(padapter, eRFPath, RegAddr, BitMask, Data);
 }
 
-u32 halbtcoutsrc_GetRfReg(void *pBtcContext, enum rf_path eRFPath, u32 RegAddr, u32 BitMask)
+static u32 halbtcoutsrc_GetRfReg(void *pBtcContext, enum rf_path eRFPath, u32 RegAddr, u32 BitMask)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2431,7 +2431,7 @@ u32 halbtcoutsrc_GetRfReg(void *pBtcContext, enum rf_path eRFPath, u32 RegAddr, 
 	return phy_query_rf_reg(padapter, eRFPath, RegAddr, BitMask);
 }
 
-u16 halbtcoutsrc_SetBtReg(void *pBtcContext, u8 RegType, u32 RegAddr, u32 Data)
+static u16 halbtcoutsrc_SetBtReg(void *pBtcContext, u8 RegType, u32 RegAddr, u32 Data)
 {
 	PBTC_COEXIST pBtCoexist;
 	u16 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -2467,7 +2467,7 @@ u16 halbtcoutsrc_SetBtReg(void *pBtcContext, u8 RegType, u32 RegAddr, u32 Data)
 	return ret;
 }
 
-u8 halbtcoutsrc_SetBtAntDetection(void *pBtcContext, u8 txTime, u8 btChnl)
+static u8 halbtcoutsrc_SetBtAntDetection(void *pBtcContext, u8 txTime, u8 btChnl)
 {
 	/* Always return _FALSE since we don't implement this yet */
 #if 0
@@ -2486,7 +2486,7 @@ u8 halbtcoutsrc_SetBtAntDetection(void *pBtcContext, u8 txTime, u8 btChnl)
 #endif
 }
 
-u8 halbtcoutsrc_SetBtTRXMASK(void *pBtcContext, u8 bt_trx_mask)
+static u8 halbtcoutsrc_SetBtTRXMASK(void *pBtcContext, u8 bt_trx_mask)
 {
 	PBTC_COEXIST 	pBtCoexist;
 	u8			bStatus = _FALSE;
@@ -2532,7 +2532,7 @@ u8 halbtcoutsrc_SetBtTRXMASK(void *pBtcContext, u8 bt_trx_mask)
 		return _FALSE;
 }
 
-u16 halbtcoutsrc_GetBtReg_with_status(void *pBtcContext, u8 RegType, u32 RegAddr, u32 *data)
+static u16 halbtcoutsrc_GetBtReg_with_status(void *pBtcContext, u8 RegType, u32 RegAddr, u32 *data)
 {
 	PBTC_COEXIST pBtCoexist;
 	u16 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -2565,14 +2565,14 @@ u16 halbtcoutsrc_GetBtReg_with_status(void *pBtcContext, u8 RegType, u32 RegAddr
 	return ret;
 }
 
-u32 halbtcoutsrc_GetBtReg(void *pBtcContext, u8 RegType, u32 RegAddr)
+static u32 halbtcoutsrc_GetBtReg(void *pBtcContext, u8 RegType, u32 RegAddr)
 {
 	u32 regVal;
 	
 	return (BT_STATUS_BT_OP_SUCCESS == halbtcoutsrc_GetBtReg_with_status(pBtcContext, RegType, RegAddr, &regVal)) ? regVal : 0xffffffff;
 }
 
-u16 halbtcoutsrc_setbttestmode(void *pBtcContext, u8 Type)
+static u16 halbtcoutsrc_setbttestmode(void *pBtcContext, u8 Type)
 {
 	PBTC_COEXIST pBtCoexist;
 	u16 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -2601,7 +2601,7 @@ u16 halbtcoutsrc_setbttestmode(void *pBtcContext, u8 Type)
 }
 
 
-void halbtcoutsrc_FillH2cCmd(void *pBtcContext, u8 elementId, u32 cmdLen, u8 *pCmdBuffer)
+static void halbtcoutsrc_FillH2cCmd(void *pBtcContext, u8 elementId, u32 cmdLen, u8 *pCmdBuffer)
 {
 	PBTC_COEXIST pBtCoexist;
 	PADAPTER padapter;
@@ -2697,7 +2697,7 @@ static COL_H2C_STATUS halbtcoutsrc_check_c2h_ack(PADAPTER Adapter, PCOL_SINGLE_H
 	return c2h_status;
 }
 
-COL_H2C_STATUS halbtcoutsrc_CoexH2cProcess(void *pBtCoexist,
+static COL_H2C_STATUS halbtcoutsrc_CoexH2cProcess(void *pBtCoexist,
 		u8 opcode, u8 opcode_ver, u8 *ph2c_par, u8 h2c_par_len)
 {
 	PADAPTER			Adapter = ((struct btc_coexist *)pBtCoexist)->Adapter;
@@ -2744,7 +2744,7 @@ COL_H2C_STATUS halbtcoutsrc_CoexH2cProcess(void *pBtCoexist,
 	return ret_status;
 }
 
-u8 halbtcoutsrc_GetAntDetValFromBt(void *pBtcContext)
+static u8 halbtcoutsrc_GetAntDetValFromBt(void *pBtcContext)
 {
 	/* Always return 0 since we don't implement this yet */
 #if 0
@@ -2764,7 +2764,7 @@ u8 halbtcoutsrc_GetAntDetValFromBt(void *pBtcContext)
 #endif
 }
 
-u8 halbtcoutsrc_GetBleScanTypeFromBt(void *pBtcContext)
+static u8 halbtcoutsrc_GetBleScanTypeFromBt(void *pBtcContext)
 {
 	PBTC_COEXIST pBtCoexist;
 	u32 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -2796,7 +2796,7 @@ u8 halbtcoutsrc_GetBleScanTypeFromBt(void *pBtcContext)
 	return data;
 }
 
-u32 halbtcoutsrc_GetBleScanParaFromBt(void *pBtcContext, u8 scanType)
+static u32 halbtcoutsrc_GetBleScanParaFromBt(void *pBtcContext, u8 scanType)
 {
 	PBTC_COEXIST pBtCoexist;
 	u32 ret = BT_STATUS_BT_OP_SUCCESS;
@@ -2829,7 +2829,7 @@ u32 halbtcoutsrc_GetBleScanParaFromBt(void *pBtcContext, u8 scanType)
 	return data;
 }
 
-u8 halbtcoutsrc_GetBtAFHMapFromBt(void *pBtcContext, u8 mapType, u8 *afhMap)
+static u8 halbtcoutsrc_GetBtAFHMapFromBt(void *pBtcContext, u8 mapType, u8 *afhMap)
 {
 	struct btc_coexist *pBtCoexist = (struct btc_coexist *)pBtcContext;
 	u8 buf[2] = {0};
@@ -2883,7 +2883,7 @@ exit:
 	return (ret == BT_STATUS_BT_OP_SUCCESS) ? _TRUE : _FALSE;
 }
 
-u8 halbtcoutsrc_SetTimer(void *pBtcContext, u32 type, u32 val)
+static u8 halbtcoutsrc_SetTimer(void *pBtcContext, u32 type, u32 val)
 {
 	struct btc_coexist *pBtCoexist=(struct btc_coexist *)pBtcContext;
 
@@ -2897,18 +2897,18 @@ u8 halbtcoutsrc_SetTimer(void *pBtcContext, u32 type, u32 val)
 	return _TRUE;
 }
 
-u32 halbtcoutsrc_SetAtomic (void *btc_ctx, u32 *target, u32 val)
+static u32 halbtcoutsrc_SetAtomic (void *btc_ctx, u32 *target, u32 val)
 {
 	*target = val;
 	return _SUCCESS;
 }
 
-void halbtcoutsrc_phydm_modify_AntDiv_HwSw(void *pBtcContext, u8 is_hw)
+static void halbtcoutsrc_phydm_modify_AntDiv_HwSw(void *pBtcContext, u8 is_hw)
 {
 	/* empty function since we don't need it */
 }
 
-void halbtcoutsrc_phydm_modify_RA_PCR_threshold(void *pBtcContext, u8 RA_offset_direction, u8 RA_threshold_offset)
+static void halbtcoutsrc_phydm_modify_RA_PCR_threshold(void *pBtcContext, u8 RA_offset_direction, u8 RA_threshold_offset)
 {
 	struct btc_coexist *pBtCoexist = (struct btc_coexist *)pBtcContext;
 
@@ -2918,7 +2918,7 @@ void halbtcoutsrc_phydm_modify_RA_PCR_threshold(void *pBtcContext, u8 RA_offset_
 #endif
 }
 
-u32 halbtcoutsrc_phydm_query_PHY_counter(void *pBtcContext, u8 info_type)
+static u32 halbtcoutsrc_phydm_query_PHY_counter(void *pBtcContext, u8 info_type)
 {
 	struct btc_coexist *pBtCoexist = (struct btc_coexist *)pBtcContext;
 
@@ -2930,7 +2930,7 @@ u32 halbtcoutsrc_phydm_query_PHY_counter(void *pBtcContext, u8 info_type)
 #endif
 }
 
-void halbtcoutsrc_reduce_wl_tx_power(void *pBtcContext, s8 tx_power)
+static void halbtcoutsrc_reduce_wl_tx_power(void *pBtcContext, s8 tx_power)
 {
 	struct btc_coexist *pBtCoexist = (struct btc_coexist *)pBtcContext;
 	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA((PADAPTER)pBtCoexist->Adapter);
@@ -3166,7 +3166,7 @@ static boolean halbtcoutsrc_btc_monitor_bt_ctr(struct btc_coexist *btc)
 /* ************************************
  *		Extern functions called by other module
  * ************************************ */
-u8 EXhalbtcoutsrc_BindBtCoexWithAdapter(void *padapter)
+static u8 EXhalbtcoutsrc_BindBtCoexWithAdapter(void *padapter)
 {
 	PBTC_COEXIST		pBtCoexist = &GLBtCoexist;
 	HAL_DATA_TYPE	*pHalData = GET_HAL_DATA((PADAPTER)padapter);
@@ -3210,7 +3210,7 @@ u8 EXhalbtcoutsrc_BindBtCoexWithAdapter(void *padapter)
 	return _TRUE;
 }
 
-void EXhalbtcoutsrc_AntInfoSetting(void *padapter)
+static void EXhalbtcoutsrc_AntInfoSetting(void *padapter)
 {
 	PBTC_COEXIST		pBtCoexist = &GLBtCoexist;
 	u8	antNum = 1, singleAntPath = 0;
@@ -3448,7 +3448,7 @@ void EXhalbtcoutsrc_PreLoadFirmware(PBTC_COEXIST pBtCoexist)
 #endif
 }
 
-void EXhalbtcoutsrc_init_hw_config(PBTC_COEXIST pBtCoexist, u8 bWifiOnly)
+static void EXhalbtcoutsrc_init_hw_config(PBTC_COEXIST pBtCoexist, u8 bWifiOnly)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -3539,7 +3539,7 @@ void EXhalbtcoutsrc_init_hw_config(PBTC_COEXIST pBtCoexist, u8 bWifiOnly)
 #endif
 }
 
-void EXhalbtcoutsrc_init_coex_dm(PBTC_COEXIST pBtCoexist)
+static void EXhalbtcoutsrc_init_coex_dm(PBTC_COEXIST pBtCoexist)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -3632,7 +3632,7 @@ void EXhalbtcoutsrc_init_coex_dm(PBTC_COEXIST pBtCoexist)
 	pBtCoexist->initilized = _TRUE;
 }
 
-void EXhalbtcoutsrc_ips_notify(PBTC_COEXIST pBtCoexist, u8 type)
+static void EXhalbtcoutsrc_ips_notify(PBTC_COEXIST pBtCoexist, u8 type)
 {
 	u8	ipsType;
 
@@ -3739,7 +3739,7 @@ void EXhalbtcoutsrc_ips_notify(PBTC_COEXIST pBtCoexist, u8 type)
 	/*	halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-void EXhalbtcoutsrc_lps_notify(PBTC_COEXIST pBtCoexist, u8 type)
+static void EXhalbtcoutsrc_lps_notify(PBTC_COEXIST pBtCoexist, u8 type)
 {
 	u8 lpsType;
 
@@ -3843,7 +3843,7 @@ void EXhalbtcoutsrc_lps_notify(PBTC_COEXIST pBtCoexist, u8 type)
 #endif
 }
 
-void EXhalbtcoutsrc_scan_notify(PBTC_COEXIST pBtCoexist, u8 type)
+static void EXhalbtcoutsrc_scan_notify(PBTC_COEXIST pBtCoexist, u8 type)
 {
 	u8	scanType;
 
@@ -3980,7 +3980,7 @@ void EXhalbtcoutsrc_SetAntennaPathNotify(PBTC_COEXIST pBtCoexist, u8 type)
 #endif
 }
 
-void EXhalbtcoutsrc_connect_notify(PBTC_COEXIST pBtCoexist, u8 assoType)
+static void EXhalbtcoutsrc_connect_notify(PBTC_COEXIST pBtCoexist, u8 assoType)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -4076,7 +4076,7 @@ void EXhalbtcoutsrc_connect_notify(PBTC_COEXIST pBtCoexist, u8 assoType)
 	/*	halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-void EXhalbtcoutsrc_media_status_notify(PBTC_COEXIST pBtCoexist, RT_MEDIA_STATUS mediaStatus)
+static void EXhalbtcoutsrc_media_status_notify(PBTC_COEXIST pBtCoexist, RT_MEDIA_STATUS mediaStatus)
 {
 	u8 mStatus = BTC_MEDIA_MAX;
 	PADAPTER adapter = NULL;
@@ -4198,7 +4198,7 @@ void EXhalbtcoutsrc_media_status_notify(PBTC_COEXIST pBtCoexist, RT_MEDIA_STATUS
 	/*	halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-void EXhalbtcoutsrc_specific_packet_notify(PBTC_COEXIST pBtCoexist, u8 pktType)
+static void EXhalbtcoutsrc_specific_packet_notify(PBTC_COEXIST pBtCoexist, u8 pktType)
 {
 	u8 packetType;
 	PADAPTER adapter = NULL;
@@ -4324,7 +4324,7 @@ void EXhalbtcoutsrc_specific_packet_notify(PBTC_COEXIST pBtCoexist, u8 pktType)
 	/*	halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-void EXhalbtcoutsrc_bt_info_notify(PBTC_COEXIST pBtCoexist, u8 *tmpBuf, u8 length)
+static void EXhalbtcoutsrc_bt_info_notify(PBTC_COEXIST pBtCoexist, u8 *tmpBuf, u8 length)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -4584,7 +4584,7 @@ void EXhalbtcoutsrc_StackOperationNotify(PBTC_COEXIST pBtCoexist, u8 type)
 #endif
 }
 
-void EXhalbtcoutsrc_halt_notify(PBTC_COEXIST pBtCoexist)
+static void EXhalbtcoutsrc_halt_notify(PBTC_COEXIST pBtCoexist)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -4675,7 +4675,7 @@ void EXhalbtcoutsrc_halt_notify(PBTC_COEXIST pBtCoexist)
 #endif
 }
 
-void EXhalbtcoutsrc_SwitchBtTRxMask(PBTC_COEXIST pBtCoexist)
+static void EXhalbtcoutsrc_SwitchBtTRxMask(PBTC_COEXIST pBtCoexist)
 {
 	if (IS_HARDWARE_TYPE_8723B(pBtCoexist->Adapter)) {
 		if (pBtCoexist->board_info.btdm_ant_num == 2) {
@@ -4686,7 +4686,7 @@ void EXhalbtcoutsrc_SwitchBtTRxMask(PBTC_COEXIST pBtCoexist)
 	}
 }
 
-void EXhalbtcoutsrc_pnp_notify(PBTC_COEXIST pBtCoexist, u8 pnpState)
+static void EXhalbtcoutsrc_pnp_notify(PBTC_COEXIST pBtCoexist, u8 pnpState)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -4935,7 +4935,7 @@ u32 EXhalbtcoutsrc_WLStatusCheck(PBTC_COEXIST pBtCoexist)
 	return change_map;
 }
 
-void EXhalbtcoutsrc_status_monitor(PBTC_COEXIST pBtCoexist)
+static void EXhalbtcoutsrc_status_monitor(PBTC_COEXIST pBtCoexist)
 {
 	u32 timer_up_type = 0, wl_status_change_type = 0;
 
@@ -4951,7 +4951,7 @@ void EXhalbtcoutsrc_status_monitor(PBTC_COEXIST pBtCoexist)
 }
 #endif
 
-void EXhalbtcoutsrc_periodical(PBTC_COEXIST pBtCoexist)
+static void EXhalbtcoutsrc_periodical(PBTC_COEXIST pBtCoexist)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -5048,7 +5048,7 @@ void EXhalbtcoutsrc_periodical(PBTC_COEXIST pBtCoexist)
 	/*	halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-void EXhalbtcoutsrc_dbg_control(PBTC_COEXIST pBtCoexist, u8 opCode, u8 opLen, u8 *pData)
+static void EXhalbtcoutsrc_dbg_control(PBTC_COEXIST pBtCoexist, u8 opCode, u8 opLen, u8 *pData)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -5386,7 +5386,7 @@ void EXhalbtcoutsrc_DisplayAntDetection(PBTC_COEXIST pBtCoexist)
 	halbtcoutsrc_NormalLowPower(pBtCoexist);
 }
 
-void ex_halbtcoutsrc_pta_off_on_notify(PBTC_COEXIST pBtCoexist, u8 bBTON)
+static void ex_halbtcoutsrc_pta_off_on_notify(PBTC_COEXIST pBtCoexist, u8 bBTON)
 {
 	if (IS_HARDWARE_TYPE_8812(pBtCoexist->Adapter)) {
 #ifdef CONFIG_RTL8812A
@@ -5403,7 +5403,7 @@ void ex_halbtcoutsrc_pta_off_on_notify(PBTC_COEXIST pBtCoexist, u8 bBTON)
 #endif
 }
 
-void EXhalbtcoutsrc_set_rfe_type(u8 type)
+static void EXhalbtcoutsrc_set_rfe_type(u8 type)
 {
 	GLBtCoexist.board_info.rfe_type= type;
 }
@@ -5420,7 +5420,7 @@ u8 EXhalbtcoutsrc_get_rf4ce_link_state(void)
 }
 #endif
 
-void EXhalbtcoutsrc_switchband_notify(struct btc_coexist *pBtCoexist, u8 type)
+static void EXhalbtcoutsrc_switchband_notify(struct btc_coexist *pBtCoexist, u8 type)
 {
 	if(!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;
@@ -5464,7 +5464,7 @@ void EXhalbtcoutsrc_switchband_notify(struct btc_coexist *pBtCoexist, u8 type)
 	/* halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-u8 EXhalbtcoutsrc_rate_id_to_btc_rate_id(u8 rate_id)
+static u8 EXhalbtcoutsrc_rate_id_to_btc_rate_id(u8 rate_id)
 {
 	u8 btc_rate_id = BTC_UNKNOWN;
 

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -2216,7 +2216,7 @@ void rtw_hal_update_sta_wset(_adapter *adapter, struct sta_info *psta)
 	psta->cmn.support_wireless_set = w_set;
 }
 
-void rtw_hal_update_sta_mimo_type(_adapter *adapter, struct sta_info *psta)
+static void rtw_hal_update_sta_mimo_type(_adapter *adapter, struct sta_info *psta)
 {
 	s8 tx_nss, rx_nss;
 
@@ -2249,7 +2249,7 @@ void rtw_hal_update_sta_mimo_type(_adapter *adapter, struct sta_info *psta)
 			psta->cmn.mac_id, tx_nss, rx_nss);
 }
 
-void rtw_hal_update_sta_smps_cap(_adapter *adapter, struct sta_info *psta)
+static void rtw_hal_update_sta_smps_cap(_adapter *adapter, struct sta_info *psta)
 {
 	/*Spatial Multiplexing Power Save*/
 #if 0
@@ -2287,7 +2287,7 @@ u8 rtw_get_mgntframe_raid(_adapter *adapter, unsigned char network_type)
 	return raid;
 }
 
-void rtw_hal_update_sta_rate_mask(PADAPTER padapter, struct sta_info *psta)
+static void rtw_hal_update_sta_rate_mask(PADAPTER padapter, struct sta_info *psta)
 {
 	u8 i, tx_nss;
 	u64 tx_ra_bitmap = 0, tmp64=0;
@@ -4814,7 +4814,7 @@ inline s32 rtw_hal_set_FwMediaStatusRpt_range_cmd(_adapter *adapter, bool opmode
 	return rtw_hal_set_FwMediaStatusRpt_cmd(adapter, opmode, miracast, miracast_sink, role, macid, 1, macid_end);
 }
 
-void rtw_hal_set_FwRsvdPage_cmd(PADAPTER padapter, PRSVDPAGE_LOC rsvdpageloc)
+static void rtw_hal_set_FwRsvdPage_cmd(PADAPTER padapter, PRSVDPAGE_LOC rsvdpageloc)
 {
 	u8	u1H2CRsvdPageParm[H2C_RSVDPAGE_LOC_LEN] = {0};
 	u8	ret = 0;
@@ -4958,7 +4958,7 @@ void rtw_hal_set_input_gpio(_adapter *padapter, u8 index)
 
 #endif
 
-void rtw_hal_set_FwAoacRsvdPage_cmd(PADAPTER padapter, PRSVDPAGE_LOC rsvdpageloc)
+static void rtw_hal_set_FwAoacRsvdPage_cmd(PADAPTER padapter, PRSVDPAGE_LOC rsvdpageloc)
 {
 	struct	pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
 	struct	mlme_priv *pmlmepriv = &padapter->mlmepriv;
@@ -8041,7 +8041,7 @@ void rtw_hal_construct_NullFunctionData(
 	*pLength = pktlen;
 }
 
-void rtw_hal_construct_ProbeRsp(_adapter *padapter, u8 *pframe, u32 *pLength,
+static void rtw_hal_construct_ProbeRsp(_adapter *padapter, u8 *pframe, u32 *pLength,
 				BOOLEAN bHideSSID)
 {
 	struct rtw_ieee80211_hdr	*pwlanhdr;
@@ -11894,7 +11894,7 @@ static _adapter * _search_ld_sta(_adapter *adapter, u8 include_self)
 #endif /*CONFIG_CONCURRENT_MODE*/
 /*Correct port0's TSF*/
 /*#define DBG_P0_TSF_SYNC*/
-void hw_var_set_correct_tsf(PADAPTER adapter, u8 mlme_state)
+static void hw_var_set_correct_tsf(PADAPTER adapter, u8 mlme_state)
 {
 #ifdef CONFIG_CONCURRENT_MODE
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
@@ -12840,7 +12840,7 @@ SetHalDefVar(_adapter *adapter, HAL_DEF_VARIABLE variable, void *value)
 }
 
 #ifdef CONFIG_BEAMFORMING
-u8 rtw_hal_query_txbfer_rf_num(_adapter *adapter)
+static u8 rtw_hal_query_txbfer_rf_num(_adapter *adapter)
 {
 	struct registry_priv	*pregistrypriv = &adapter->registrypriv;
 	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(adapter);
@@ -12865,7 +12865,7 @@ u8 rtw_hal_query_txbfer_rf_num(_adapter *adapter)
 		return 1;
 
 }
-u8 rtw_hal_query_txbfee_rf_num(_adapter *adapter)
+static u8 rtw_hal_query_txbfee_rf_num(_adapter *adapter)
 {
 	struct registry_priv		*pregistrypriv = &adapter->registrypriv;
 	struct mlme_ext_priv	*pmlmeext = &adapter->mlmeextpriv;
@@ -15282,7 +15282,7 @@ void rtw_dump_phy_cap_by_phydmapi(void *sel, _adapter *adapter)
 	#endif
 }
 #else
-void rtw_dump_phy_cap_by_hal(void *sel, _adapter *adapter)
+static void rtw_dump_phy_cap_by_hal(void *sel, _adapter *adapter)
 {
 	u8 phy_cap = _FALSE;
 

--- a/hal/hal_com_phycfg.c
+++ b/hal/hal_com_phycfg.c
@@ -693,7 +693,7 @@ static inline void hal_init_pg_txpwr_info_5g(_adapter *adapter, TxPowerInfo5G *p
 #define LOAD_PG_TXPWR_WARN_COND(_txpwr_src) (_txpwr_src > PG_TXPWR_SRC_PG_DATA)
 #endif
 
-u16 hal_load_pg_txpwr_info_path_2g(
+static u16 hal_load_pg_txpwr_info_path_2g(
 	_adapter *adapter,
 	TxPowerInfo24G	*pwr_info,
 	u32 path,
@@ -822,7 +822,7 @@ exit:
 	return offset;
 }
 
-u16 hal_load_pg_txpwr_info_path_5g(
+static u16 hal_load_pg_txpwr_info_path_5g(
 	_adapter *adapter,
 	TxPowerInfo5G	*pwr_info,
 	u32 path,
@@ -982,7 +982,7 @@ exit:
 	return offset;
 }
 
-void hal_load_pg_txpwr_info(
+static void hal_load_pg_txpwr_info(
 	_adapter *adapter,
 	TxPowerInfo24G *pwr_info_2g,
 	TxPowerInfo5G *pwr_info_5g,
@@ -1416,7 +1416,7 @@ void dump_hal_txpwr_info_5g(void *sel, _adapter *adapter, u8 rfpath_num, u8 max_
 *
 * Return dBm or -1 for undefined
 */
-s8 rtw_regsty_get_target_tx_power(
+static s8 rtw_regsty_get_target_tx_power(
 		PADAPTER		Adapter,
 		u8				Band,
 		u8				RfPath,
@@ -1460,7 +1460,7 @@ s8 rtw_regsty_get_target_tx_power(
 	return value;
 }
 
-bool rtw_regsty_chk_target_tx_power_valid(_adapter *adapter)
+static bool rtw_regsty_chk_target_tx_power_valid(_adapter *adapter)
 {
 	struct hal_spec_t *hal_spec = GET_HAL_SPEC(adapter);
 	int path, tx_num, band, rs;
@@ -1653,7 +1653,7 @@ static void phy_txpwr_by_rate_chk_for_path_dup(_adapter *adapter)
 	}
 }
 
-void phy_store_target_tx_power(PADAPTER	pAdapter)
+static void phy_store_target_tx_power(PADAPTER	pAdapter)
 {
 	struct hal_spec_t *hal_spec = GET_HAL_SPEC(pAdapter);
 	struct registry_priv *regsty = adapter_to_regsty(pAdapter);
@@ -2085,7 +2085,7 @@ PHY_GetRateValuesOfTxPowerByRate(
 	};
 }
 
-void
+static void
 PHY_StoreTxPowerByRateNew(
 		PADAPTER	pAdapter,
 		u32			Band,
@@ -2219,7 +2219,7 @@ exit:
 	return;
 }
 
-bool phy_get_ch_idx(u8 ch, u8 *ch_idx)
+static bool phy_get_ch_idx(u8 ch, u8 *ch_idx)
 {
 	u8  i = 0;
 	BOOLEAN bIn24G = _TRUE;
@@ -3561,7 +3561,7 @@ static void phy_txpwr_lmt_post_hdl(_adapter *adapter)
 	_exit_critical_mutex(&rfctl->txpwr_lmt_mutex, &irqL);
 }
 
-BOOLEAN
+static BOOLEAN
 GetS1ByteIntegerFromStringInDecimal(
 			char	*str,
 			s8		*val
@@ -3766,7 +3766,7 @@ void dump_tx_power_index_inline(void *sel, _adapter *adapter, u8 rfpath, enum ch
 	}
 }
 
-void dump_tx_power_idx_value(void *sel, _adapter *adapter, u8 rfpath, enum MGN_RATE rate, u8 pwr_idx, struct txpwr_idx_comp *tic)
+static void dump_tx_power_idx_value(void *sel, _adapter *adapter, u8 rfpath, enum MGN_RATE rate, u8 pwr_idx, struct txpwr_idx_comp *tic)
 {
 	struct hal_spec_t *hal_spec = GET_HAL_SPEC(adapter);
 	char tmp_str[8];
@@ -3870,7 +3870,7 @@ void dump_tx_power_idx(void *sel, _adapter *adapter, enum channel_width bw, u8 c
 			dump_tx_power_idx_by_path_rs(sel, adapter, rfpath, rs, bw, cch, opch);
 }
 
-void dump_txpwr_total_dbm_value(void *sel, _adapter *adapter, enum MGN_RATE rate, u8 ntx_idx
+static void dump_txpwr_total_dbm_value(void *sel, _adapter *adapter, enum MGN_RATE rate, u8 ntx_idx
 	, s16 target, s16 byr, s16 btc, s16 extra, s16 lmt, s16 ulmt, s16 tpc)
 {
 	char target_str[8];
@@ -3894,7 +3894,7 @@ void dump_txpwr_total_dbm_value(void *sel, _adapter *adapter, enum MGN_RATE rate
 		, target_str, byr_str, btc_str, extra_str, lmt_str, ulmt_str, tpc_str);
 }
 
-void dump_txpwr_total_dbm_value_utgt(void *sel, _adapter *adapter, enum MGN_RATE rate, u8 ntx_idx
+static void dump_txpwr_total_dbm_value_utgt(void *sel, _adapter *adapter, enum MGN_RATE rate, u8 ntx_idx
 	, s16 target, s16 utgt, s16 lmt, s16 ulmt, s16 tpc)
 {
 	char target_str[8];
@@ -4489,7 +4489,7 @@ phy_ConfigBBWithParaFile(
 	return rtStatus;
 }
 
-void
+static void
 phy_DecryptBBPgParaFile(
 	PADAPTER		Adapter,
 	char			*buffer
@@ -4531,7 +4531,7 @@ phy_DecryptBBPgParaFile(
 #define DBG_TXPWR_BY_RATE_FILE_PARSE 0
 #endif
 
-int
+static int
 phy_ParseBBPgParaFile(
 	PADAPTER		Adapter,
 	char			*buffer
@@ -4963,7 +4963,7 @@ PHY_ConfigRFWithParaFile(
 	return rtStatus;
 }
 
-void
+static void
 initDeltaSwingIndexTables(
 	PADAPTER	Adapter,
 	char		*Band,
@@ -5685,7 +5685,7 @@ bool phy_is_txpwr_user_target_specified(_adapter *adapter)
 * Return value in unit of TX Gain Index
 * hal_spec.txgi_max means unspecified
 */
-s8 phy_get_txpwr_user_target(_adapter *adapter, struct hal_spec_t *hal_spec, u8 ntx_idx)
+static s8 phy_get_txpwr_user_target(_adapter *adapter, struct hal_spec_t *hal_spec, u8 ntx_idx)
 {
 	s16 total_mbm = UNSPECIFIED_MBM;
 	s8 target;
@@ -5705,7 +5705,7 @@ s8 phy_get_txpwr_user_target(_adapter *adapter, struct hal_spec_t *hal_spec, u8 
 * Return value in unit of TX Gain Index
 * hal_spec.txgi_max means unspecified
 */
-s8 phy_get_txpwr_user_lmt(_adapter *adapter, struct hal_spec_t *hal_spec, u8 ntx_idx)
+static s8 phy_get_txpwr_user_lmt(_adapter *adapter, struct hal_spec_t *hal_spec, u8 ntx_idx)
 {
 	s16 total_mbm = UNSPECIFIED_MBM;
 	s8 lmt;
@@ -5725,7 +5725,7 @@ s8 phy_get_txpwr_user_lmt(_adapter *adapter, struct hal_spec_t *hal_spec, u8 ntx
 * Return value in unit of TX Gain Index
 * 0 means unspecified
 */
-s8 phy_get_txpwr_tpc(_adapter *adapter, struct hal_spec_t *hal_spec)
+static s8 phy_get_txpwr_tpc(_adapter *adapter, struct hal_spec_t *hal_spec)
 {
 	struct rf_ctl_t *rfctl = adapter_to_rfctl(adapter);
 	u16 cnst = 0;

--- a/hal/hal_dm.c
+++ b/hal/hal_dm.c
@@ -17,7 +17,7 @@
 #include <hal_data.h>
 
 /* A mapping from HalData to ODM. */
-enum odm_board_type boardType(u8 InterfaceSel)
+static enum odm_board_type boardType(u8 InterfaceSel)
 {
 	enum odm_board_type        board	= ODM_BOARD_DEFAULT;
 
@@ -106,7 +106,7 @@ void rtw_phydm_iqk_trigger(_adapter *adapter)
 }
 #endif
 
-void rtw_phydm_iqk_trigger_dbg(_adapter *adapter, bool recovery, bool clear, bool segment)
+static void rtw_phydm_iqk_trigger_dbg(_adapter *adapter, bool recovery, bool clear, bool segment)
 {
 	struct dm_struct *p_dm_odm = adapter_to_phydm(adapter);
 
@@ -116,7 +116,7 @@ void rtw_phydm_iqk_trigger_dbg(_adapter *adapter, bool recovery, bool clear, boo
 		halrf_iqk_trigger(p_dm_odm, recovery);
 #endif
 }
-void rtw_phydm_lck_trigger(_adapter *adapter)
+static void rtw_phydm_lck_trigger(_adapter *adapter)
 {
 	struct dm_struct *p_dm_odm = adapter_to_phydm(adapter);
 
@@ -192,7 +192,7 @@ void record_ra_info(void *p_dm_void, u8 macid, struct cmn_sta_info *p_sta, u64 r
 }
 
 #ifdef CONFIG_SUPPORT_DYNAMIC_TXPWR
-void rtw_phydm_fill_desc_dpt(void *dm, u8 *desc, u8 dpt_lv)
+static void rtw_phydm_fill_desc_dpt(void *dm, u8 *desc, u8 dpt_lv)
 {
 	struct dm_struct *p_dm = (struct dm_struct *)dm;
 	_adapter *adapter = p_dm->adapter;
@@ -294,7 +294,7 @@ void rtw_phydm_tdmadig(_adapter *adapter, u8 state)
 	}
 }
 #endif/*CONFIG_TDMADIG*/
-void rtw_phydm_ops_func_init(struct dm_struct *p_phydm)
+static void rtw_phydm_ops_func_init(struct dm_struct *p_phydm)
 {
 	struct ra_table *p_ra_t = &p_phydm->dm_ra_table;
 

--- a/hal/hal_intf.c
+++ b/hal/hal_intf.c
@@ -266,7 +266,7 @@ void dump_hal_trx_mode(void *sel, _adapter *adapter)
 	dump_hal_runtime_trx_mode(sel, adapter);
 }
 
-void _dump_rf_path(void *sel, _adapter *adapter)
+static void _dump_rf_path(void *sel, _adapter *adapter)
 {
 	PHAL_DATA_TYPE hal_data = GET_HAL_DATA(adapter);
 	struct hal_spec_t *hal_spec = GET_HAL_SPEC(adapter);
@@ -364,7 +364,7 @@ if (IS_HARDWARE_TYPE_8814A(adapter)) {
 	return _SUCCESS;
 }
 
-void _dump_trx_nss(void *sel, _adapter *adapter)
+static void _dump_trx_nss(void *sel, _adapter *adapter)
 {
 	struct registry_priv *regpriv = &adapter->registrypriv;
 	struct hal_spec_t *hal_spec = GET_HAL_SPEC(adapter);
@@ -468,7 +468,7 @@ void rtw_hal_power_off(_adapter *padapter)
 }
 
 
-void rtw_hal_init_opmode(_adapter *padapter)
+static void rtw_hal_init_opmode(_adapter *padapter)
 {
 	NDIS_802_11_NETWORK_INFRASTRUCTURE networkType = Ndis802_11InfrastructureMax;
 	struct  mlme_priv *pmlmepriv = &(padapter->mlmepriv);
@@ -881,7 +881,7 @@ void	rtw_hal_free_recv_priv(_adapter *padapter)
 	padapter->hal_func.free_recv_priv(padapter);
 }
 
-void rtw_sta_ra_registed(_adapter *padapter, struct sta_info *psta)
+static void rtw_sta_ra_registed(_adapter *padapter, struct sta_info *psta)
 {
 	HAL_DATA_TYPE *hal_data = GET_HAL_DATA(padapter);
 

--- a/hal/hal_mp.c
+++ b/hal/hal_mp.c
@@ -366,7 +366,7 @@ void hal_mpt_SetBandwidth(PADAPTER pAdapter)
 
 }
 
-void mpt_SetTxPower_Old(PADAPTER pAdapter, MPT_TXPWR_DEF Rate, u8 *pTxPower)
+static void mpt_SetTxPower_Old(PADAPTER pAdapter, MPT_TXPWR_DEF Rate, u8 *pTxPower)
 {
 	switch (Rate) {
 	case MPT_CCK: {
@@ -423,7 +423,7 @@ void mpt_SetTxPower_Old(PADAPTER pAdapter, MPT_TXPWR_DEF Rate, u8 *pTxPower)
 	RTW_INFO("<===mpt_SetTxPower_Old()\n");
 }
 
-void
+static void
 mpt_SetTxPower(
 	PADAPTER		pAdapter,
 	MPT_TXPWR_DEF	Rate,
@@ -861,7 +861,7 @@ void mpt_SetRFPath_8814A(PADAPTER	pAdapter)
 
 #endif /* CONFIG_RTL8814A */
 #if defined(CONFIG_RTL8814A) || defined(CONFIG_RTL8822B) || defined(CONFIG_RTL8821C)  || defined(CONFIG_RTL8822C) || defined(CONFIG_RTL8814B)
-void
+static void
 mpt_SetSingleTone_8814A(
 		PADAPTER	pAdapter,
 		BOOLEAN	bSingleTone,
@@ -1290,7 +1290,7 @@ void mpt_SetRFPath_8723D(PADAPTER pAdapter)
 }
 #endif
 
-void mpt_SetRFPath_819X(PADAPTER	pAdapter)
+static void mpt_SetRFPath_819X(PADAPTER	pAdapter)
 {
 	HAL_DATA_TYPE			*pHalData	= GET_HAL_DATA(pAdapter);
 	PMPT_CONTEXT		pMptCtx = &(pAdapter->mppriv.mpt_ctx);

--- a/hal/phydm/halrf/halphyrf_ce.c
+++ b/hal/phydm/halrf/halphyrf_ce.c
@@ -164,7 +164,7 @@ void odm_clear_txpowertracking_state(void *dm_void)
 	cali_info->modify_tx_agc_value_ofdm = 0;
 }
 
-void odm_get_tracking_table(void *dm_void, u8 thermal_value, u8 delta)
+static void odm_get_tracking_table(void *dm_void, u8 thermal_value, u8 delta)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_rf_calibration_struct *cali_info = &dm->rf_calibrate_info;
@@ -367,7 +367,7 @@ void odm_get_tracking_table(void *dm_void, u8 thermal_value, u8 delta)
 	}
 }
 
-void odm_pwrtrk_method(void *dm_void)
+static void odm_pwrtrk_method(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 p, idxforchnl = 0;

--- a/hal/phydm/halrf/halrf.c
+++ b/hal/phydm/halrf/halrf.c
@@ -45,7 +45,7 @@ void _iqk_check_if_reload(void *dm_void)
 	iqk_info->is_reload = (boolean)odm_get_bb_reg(dm, R_0x1bf0, BIT(16));
 }
 
-void _iqk_page_switch(void *dm_void)
+static void _iqk_page_switch(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -97,7 +97,7 @@ u32 halrf_psd_log2base(u32 val)
 }
 #if (RTL8822B_SUPPORT == 1 || RTL8821C_SUPPORT == 1 ||\
 	RTL8814B_SUPPORT == 1 || RTL8822C_SUPPORT == 1)
-void halrf_iqk_xym_enable(struct dm_struct *dm, u8 xym_enable)
+static void halrf_iqk_xym_enable(struct dm_struct *dm, u8 xym_enable)
 {
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
 
@@ -194,7 +194,7 @@ void halrf_iqk_xym_read(void *dm_void, u8 path, u8 xym_type)
 }
 
 /*xym_type => 0: rx_sym; 1: tx_xym; 2:gs1_xym; 3:gs2_sym; 4: rxk1_xym*/
-void halrf_iqk_xym_show(struct dm_struct *dm, u8 xym_type)
+static void halrf_iqk_xym_show(struct dm_struct *dm, u8 xym_type)
 {
 	u8 num, path, path_num, i;
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
@@ -259,7 +259,7 @@ void halrf_iqk_xym_show(struct dm_struct *dm, u8 xym_type)
 	}
 }
 
-void halrf_iqk_xym_dump(void *dm_void)
+static void halrf_iqk_xym_dump(void *dm_void)
 {
 	u32 tmp1, tmp2;
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -367,7 +367,7 @@ void halrf_iqk_info_dump(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 	*_out_len = out_len;
 }
 
-void halrf_get_fw_version(void *dm_void)
+static void halrf_get_fw_version(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct _hal_rf_ *rf = &dm->rf_table;
@@ -460,7 +460,7 @@ void halrf_iqk_dbg(void *dm_void)
 #endif
 }
 
-void halrf_lck_dbg(struct dm_struct *dm)
+static void halrf_lck_dbg(struct dm_struct *dm)
 {
 	RF_DBG(dm, DBG_RF_IQK, "%-20s\n", "====== LCK Info ======");
 #if 0
@@ -497,7 +497,7 @@ void phydm_get_iqk_cfir(void *dm_void, u8 idx, u8 path, boolean debug)
 }
 
 
-void halrf_iqk_dbg_cfir_backup(void *dm_void)
+static void halrf_iqk_dbg_cfir_backup(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
@@ -525,7 +525,7 @@ void halrf_iqk_dbg_cfir_backup(void *dm_void)
 
 }
 
-void halrf_iqk_dbg_cfir_backup_update(void *dm_void)
+static void halrf_iqk_dbg_cfir_backup_update(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_iqk_info *iqk = &dm->IQK_info;
@@ -550,7 +550,7 @@ void halrf_iqk_dbg_cfir_backup_update(void *dm_void)
 	}
 }
 
-void halrf_iqk_dbg_cfir_reload(void *dm_void)
+static void halrf_iqk_dbg_cfir_reload(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_iqk_info *iqk = &dm->IQK_info;
@@ -575,7 +575,7 @@ void halrf_iqk_dbg_cfir_reload(void *dm_void)
 	}
 }
 
-void halrf_iqk_dbg_cfir_write(void *dm_void, u8 type, u32 path, u32 idx,
+static void halrf_iqk_dbg_cfir_write(void *dm_void, u8 type, u32 path, u32 idx,
 			      u32 i, u32 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -597,7 +597,7 @@ void halrf_iqk_dbg_cfir_write(void *dm_void, u8 type, u32 path, u32 idx,
 	}
 }
 
-void halrf_iqk_dbg_cfir_backup_show(void *dm_void)
+static void halrf_iqk_dbg_cfir_backup_show(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
@@ -1056,7 +1056,7 @@ u64 halrf_cmn_info_get(void *dm_void, u32 cmn_info)
 	return return_value;
 }
 
-void halrf_supportability_init_mp(void *dm_void)
+static void halrf_supportability_init_mp(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct _hal_rf_ *rf = &dm->rf_table;
@@ -1481,7 +1481,7 @@ void halrf_rfk_handshake(void *dm_void, boolean is_before_k)
 	}
 }
 
-void halrf_bbreset(void *dm_void)
+static void halrf_bbreset(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -2119,7 +2119,7 @@ void halrf_lck_trigger(void *dm_void)
 	}
 }
 
-void halrf_aac_check(struct dm_struct *dm)
+static void halrf_aac_check(struct dm_struct *dm)
 {
 	switch (dm->support_ic_type) {
 #if (RTL8821C_SUPPORT == 1)
@@ -2160,7 +2160,7 @@ void halrf_rxdck(void *dm_void)
 	}
 }
 
-void halrf_x2k_check(struct dm_struct *dm)
+static void halrf_x2k_check(struct dm_struct *dm)
 {
 
 	switch (dm->support_ic_type) {
@@ -2198,7 +2198,7 @@ void halrf_set_rfsupportability(void *dm_void)
 	}
 }
 
-void halrf_rfe_definition(struct dm_struct *dm)
+static void halrf_rfe_definition(struct dm_struct *dm)
 {
 	struct _hal_rf_ *rf = &dm->rf_table;
 
@@ -2216,7 +2216,7 @@ void halrf_rfe_definition(struct dm_struct *dm)
 	}
 }
 
-void halrf_rfe_type_setting(struct dm_struct *dm)
+static void halrf_rfe_type_setting(struct dm_struct *dm)
 {
 	switch (dm->support_ic_type) {
 	case ODM_RTL8822C:
@@ -2924,7 +2924,7 @@ void halrf_dpk_switch(void *dm_void, u8 enable)
 	}
 }
 
-void _halrf_dpk_info_by_chip(void *dm_void, u32 *_used, char *output, u32 *_out_len)
+static void _halrf_dpk_info_by_chip(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -2958,7 +2958,7 @@ void _halrf_dpk_info_by_chip(void *dm_void, u32 *_used, char *output, u32 *_out_
 	*_out_len = out_len;
 }
 
-void _halrf_display_dpk_info(void *dm_void, u32 *_used, char *output, u32 *_out_len)
+static void _halrf_display_dpk_info(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_dpk_info *dpk_info = &dm->dpk_info;
@@ -3930,7 +3930,7 @@ void halrf_txgap_enable_disable(void *dm_void, u8 enable)
 	}
 }
 
-void _halrf_dump_subpage(void *dm_void, u32 *_used, char *output, u32 *_out_len, u8 page)
+static void _halrf_dump_subpage(void *dm_void, u32 *_used, char *output, u32 *_out_len, u8 page)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 

--- a/hal/phydm/halrf/halrf_debug.c
+++ b/hal/phydm/halrf/halrf_debug.c
@@ -31,7 +31,7 @@
 #include "mp_precomp.h"
 #include "phydm_precomp.h"
 
-void halrf_basic_profile(void *dm_void, u32 *_used, char *output, u32 *_out_len)
+static void halrf_basic_profile(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 {
 #ifdef CONFIG_PHYDM_DEBUG_FUNCTION
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -139,7 +139,7 @@ void halrf_basic_profile(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 #endif
 }
 
-void halrf_debug_trace(void *dm_void, char input[][16], u32 *_used,
+static void halrf_debug_trace(void *dm_void, char input[][16], u32 *_used,
 		       char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -199,7 +199,7 @@ void halrf_debug_trace(void *dm_void, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-void halrf_dack_debug_cmd(void *dm_void, char input[][16])
+static void halrf_dack_debug_cmd(void *dm_void, char input[][16])
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct _hal_rf_ *rf = &dm->rf_table;

--- a/hal/phydm/halrf/halrf_kfree.c
+++ b/hal/phydm/halrf/halrf_kfree.c
@@ -32,7 +32,7 @@
 /*@<YuChen, 150720> Add for KFree Feature Requested by RF David.*/
 /*@This is a phydm API*/
 
-void phydm_set_kfree_to_rf_8814a(void *dm_void, u8 e_rf_path, u8 data)
+static void phydm_set_kfree_to_rf_8814a(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_rf_calibration_struct *cali_info = &dm->rf_calibrate_info;
@@ -124,7 +124,7 @@ void phydm_set_kfree_to_rf_8814a(void *dm_void, u8 e_rf_path, u8 data)
 	}
 }
 
-void phydm_get_thermal_trim_offset_8821c(void *dm_void)
+static void phydm_get_thermal_trim_offset_8821c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -151,7 +151,7 @@ void phydm_get_thermal_trim_offset_8821c(void *dm_void)
 		       power_trim_info->thermal);
 }
 
-void phydm_get_power_trim_offset_8821c(void *dm_void)
+static void phydm_get_power_trim_offset_8821c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -188,7 +188,7 @@ void phydm_get_power_trim_offset_8821c(void *dm_void)
 	}
 }
 
-void phydm_set_kfree_to_rf_8821c(void *dm_void, u8 e_rf_path, boolean wlg_btg,
+static void phydm_set_kfree_to_rf_8821c(void *dm_void, u8 e_rf_path, boolean wlg_btg,
 				 u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -223,7 +223,7 @@ void phydm_set_kfree_to_rf_8821c(void *dm_void, u8 e_rf_path, boolean wlg_btg,
 	       odm_get_rf_reg(dm, e_rf_path, RF_0x65, s_gain_bmask));
 }
 
-void phydm_clear_kfree_to_rf_8821c(void *dm_void, u8 e_rf_path, u8 data)
+static void phydm_clear_kfree_to_rf_8821c(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 gain_bmask = (BIT(18) | BIT(17) | BIT(16) | BIT(15) | BIT(14));
@@ -252,7 +252,7 @@ void phydm_clear_kfree_to_rf_8821c(void *dm_void, u8 e_rf_path, u8 data)
 	       odm_get_rf_reg(dm, e_rf_path, RF_0x65, s_gain_bmask));
 }
 
-void phydm_get_thermal_trim_offset_8822b(void *dm_void)
+static void phydm_get_thermal_trim_offset_8822b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -279,7 +279,7 @@ void phydm_get_thermal_trim_offset_8822b(void *dm_void)
 		       power_trim_info->thermal);
 }
 
-void phydm_get_power_trim_offset_8822b(void *dm_void)
+static void phydm_get_power_trim_offset_8822b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -346,7 +346,7 @@ void phydm_get_power_trim_offset_8822b(void *dm_void)
 	}
 }
 
-void phydm_set_pa_bias_to_rf_8822b(void *dm_void, u8 e_rf_path, s8 tx_pa_bias)
+static void phydm_set_pa_bias_to_rf_8822b(void *dm_void, u8 e_rf_path, s8 tx_pa_bias)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 rf_reg_51 = 0, rf_reg_52 = 0, rf_reg_3f = 0;
@@ -405,7 +405,7 @@ void phydm_set_pa_bias_to_rf_8822b(void *dm_void, u8 e_rf_path, s8 tx_pa_bias)
 			      e_rf_path);
 }
 
-void phydm_get_pa_bias_offset_8822b(void *dm_void)
+static void phydm_get_pa_bias_offset_8822b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -450,7 +450,7 @@ void phydm_get_pa_bias_offset_8822b(void *dm_void)
 	}
 }
 
-void phydm_set_kfree_to_rf_8822b(void *dm_void, u8 e_rf_path, u8 data)
+static void phydm_set_kfree_to_rf_8822b(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 gain_bmask = (BIT(18) | BIT(17) | BIT(16) | BIT(15) | BIT(14));
@@ -470,7 +470,7 @@ void phydm_set_kfree_to_rf_8822b(void *dm_void, u8 e_rf_path, u8 data)
 			      BIT(15) | BIT(14))), e_rf_path);
 }
 
-void phydm_clear_kfree_to_rf_8822b(void *dm_void, u8 e_rf_path, u8 data)
+static void phydm_clear_kfree_to_rf_8822b(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 gain_bmask = (BIT(18) | BIT(17) | BIT(16) | BIT(15) | BIT(14));
@@ -497,7 +497,7 @@ void phydm_clear_kfree_to_rf_8822b(void *dm_void, u8 e_rf_path, u8 data)
 			      BIT(15) | BIT(14))), e_rf_path);
 }
 
-void phydm_get_thermal_trim_offset_8710b(void *dm_void)
+static void phydm_get_thermal_trim_offset_8710b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -524,7 +524,7 @@ void phydm_get_thermal_trim_offset_8710b(void *dm_void)
 		       power_trim_info->thermal);
 }
 
-void phydm_get_power_trim_offset_8710b(void *dm_void)
+static void phydm_get_power_trim_offset_8710b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -551,7 +551,7 @@ void phydm_get_power_trim_offset_8710b(void *dm_void)
 		       power_trim_info->bb_gain[0][0]);
 }
 
-void phydm_set_kfree_to_rf_8710b(void *dm_void, u8 e_rf_path, u8 data)
+static void phydm_set_kfree_to_rf_8710b(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 gain_bmask = (BIT(18) | BIT(17) | BIT(16) | BIT(15));
@@ -565,7 +565,7 @@ void phydm_set_kfree_to_rf_8710b(void *dm_void, u8 e_rf_path, u8 data)
 			      BIT(15) | BIT(14))), e_rf_path);
 }
 
-void phydm_clear_kfree_to_rf_8710b(void *dm_void, u8 e_rf_path, u8 data)
+static void phydm_clear_kfree_to_rf_8710b(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 gain_bmask = (BIT(18) | BIT(17) | BIT(16) | BIT(15) | BIT(14));
@@ -581,7 +581,7 @@ void phydm_clear_kfree_to_rf_8710b(void *dm_void, u8 e_rf_path, u8 data)
 			      BIT(15) | BIT(14))), e_rf_path);
 }
 
-void phydm_get_thermal_trim_offset_8192f(void *dm_void)
+static void phydm_get_thermal_trim_offset_8192f(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -608,7 +608,7 @@ void phydm_get_thermal_trim_offset_8192f(void *dm_void)
 		       power_trim_info->thermal);
 }
 
-void phydm_get_power_trim_offset_8192f(void *dm_void)
+static void phydm_get_power_trim_offset_8192f(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -677,7 +677,7 @@ void phydm_get_power_trim_offset_8192f(void *dm_void)
 	}
 }
 
-void phydm_set_kfree_to_rf_8192f(void *dm_void, u8 e_rf_path, u8 channel_idx,
+static void phydm_set_kfree_to_rf_8192f(void *dm_void, u8 e_rf_path, u8 channel_idx,
 				 u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -765,7 +765,7 @@ void phydm_clear_kfree_to_rf_8192f(void *dm_void, u8 e_rf_path, u8 data)
 */
 #endif
 
-void phydm_get_thermal_trim_offset_8198f(void *dm_void)
+static void phydm_get_thermal_trim_offset_8198f(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -792,7 +792,7 @@ void phydm_get_thermal_trim_offset_8198f(void *dm_void)
 		       power_trim_info->thermal);
 }
 
-void phydm_get_power_trim_offset_8198f(void *dm_void)
+static void phydm_get_power_trim_offset_8198f(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -843,7 +843,7 @@ void phydm_get_power_trim_offset_8198f(void *dm_void)
 	}
 }
 
-void phydm_get_pa_bias_offset_8198f(void *dm_void)
+static void phydm_get_pa_bias_offset_8198f(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -890,7 +890,7 @@ void phydm_get_pa_bias_offset_8198f(void *dm_void)
 	}
 }
 
-void phydm_get_set_lna_offset_8198f(void *dm_void)
+static void phydm_get_set_lna_offset_8198f(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -955,7 +955,7 @@ void phydm_get_set_lna_offset_8198f(void *dm_void)
 }
 
 
-void phydm_set_kfree_to_rf_8198f(void *dm_void, u8 e_rf_path, u8 data)
+static void phydm_set_kfree_to_rf_8198f(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -997,7 +997,7 @@ void phydm_set_kfree_to_rf_8198f(void *dm_void, u8 e_rf_path, u8 data)
 
 }
 
-void phydm_clear_kfree_to_rf_8198f(void *dm_void, u8 e_rf_path, u8 data)
+static void phydm_clear_kfree_to_rf_8198f(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -1041,7 +1041,7 @@ void phydm_clear_kfree_to_rf_8198f(void *dm_void, u8 e_rf_path, u8 data)
 
 }
 
-void phydm_get_set_thermal_trim_offset_8822c(void *dm_void)
+static void phydm_get_set_thermal_trim_offset_8822c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1081,7 +1081,7 @@ void phydm_get_set_thermal_trim_offset_8822c(void *dm_void)
 			thermal[RF_PATH_B]);	
 }
 
-void phydm_set_power_trim_offset_8822c(void *dm_void)
+static void phydm_set_power_trim_offset_8822c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1141,7 +1141,7 @@ void phydm_set_power_trim_offset_8822c(void *dm_void)
 	}
 }
 
-void phydm_get_set_power_trim_offset_8822c(void *dm_void)
+static void phydm_get_set_power_trim_offset_8822c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1242,7 +1242,7 @@ void phydm_get_set_power_trim_offset_8822c(void *dm_void)
 	}
 }
 
-void phydm_get_tssi_trim_offset_8822c(void *dm_void)
+static void phydm_get_tssi_trim_offset_8822c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1310,7 +1310,7 @@ void phydm_get_tssi_trim_offset_8822c(void *dm_void)
 	}
 }
 
-s8 phydm_get_tssi_trim_de_8822c(void *dm_void, u8 path)
+static s8 phydm_get_tssi_trim_de_8822c(void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1346,7 +1346,7 @@ s8 phydm_get_tssi_trim_de_8822c(void *dm_void, u8 path)
 
 
 
-void phydm_get_set_pa_bias_offset_8822c(void *dm_void)
+static void phydm_get_set_pa_bias_offset_8822c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1401,7 +1401,7 @@ void phydm_get_set_pa_bias_offset_8822c(void *dm_void)
 
 }
 
-void phydm_get_set_thermal_trim_offset_8812f(void *dm_void)
+static void phydm_get_set_thermal_trim_offset_8812f(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1441,7 +1441,7 @@ void phydm_get_set_thermal_trim_offset_8812f(void *dm_void)
 			thermal[RF_PATH_B]);	
 }
 
-void phydm_set_power_trim_offset_8812f(void *dm_void)
+static void phydm_set_power_trim_offset_8812f(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1503,7 +1503,7 @@ void phydm_set_power_trim_offset_8812f(void *dm_void)
 	}
 }
 
-void phydm_get_set_power_trim_offset_8812f(void *dm_void)
+static void phydm_get_set_power_trim_offset_8812f(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1604,7 +1604,7 @@ void phydm_get_set_power_trim_offset_8812f(void *dm_void)
 	}
 }
 
-void phydm_get_tssi_trim_offset_8812f(void *dm_void)
+static void phydm_get_tssi_trim_offset_8812f(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1676,7 +1676,7 @@ void phydm_get_tssi_trim_offset_8812f(void *dm_void)
 	}
 }
 
-s8 phydm_get_tssi_trim_de_8812f(void *dm_void, u8 path)
+static s8 phydm_get_tssi_trim_de_8812f(void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1710,7 +1710,7 @@ s8 phydm_get_tssi_trim_de_8812f(void *dm_void, u8 path)
 	return power_trim_info->tssi_trim[group][path];
 }
 
-void phydm_get_set_pa_bias_offset_8812f(void *dm_void)
+static void phydm_get_set_pa_bias_offset_8812f(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1767,7 +1767,7 @@ void phydm_get_set_pa_bias_offset_8812f(void *dm_void)
 
 }
 
-void phydm_get_thermal_trim_offset_8195b(void *dm_void)
+static void phydm_get_thermal_trim_offset_8195b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1794,7 +1794,7 @@ void phydm_get_thermal_trim_offset_8195b(void *dm_void)
 		       power_trim_info->thermal);
 }
 
-void phydm_set_power_trim_rf_8195b(void *dm_void)
+static void phydm_set_power_trim_rf_8195b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1838,7 +1838,7 @@ void phydm_set_power_trim_rf_8195b(void *dm_void)
 
 }
 
-void phydm_get_set_power_trim_offset_8195b(void *dm_void)
+static void phydm_get_set_power_trim_offset_8195b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1892,7 +1892,7 @@ void phydm_get_set_power_trim_offset_8195b(void *dm_void)
 	}
 }
 
-void phydm_get_set_pa_bias_offset_8195b(void *dm_void)
+static void phydm_get_set_pa_bias_offset_8195b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1928,7 +1928,7 @@ void phydm_get_set_pa_bias_offset_8195b(void *dm_void)
 	}
 }
 
-void phydm_get_thermal_trim_offset_8721d(void *dm_void)
+static void phydm_get_thermal_trim_offset_8721d(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -1955,7 +1955,7 @@ void phydm_get_thermal_trim_offset_8721d(void *dm_void)
 		       power_trim_info->thermal);
 }
 
-void phydm_set_power_trim_rf_8721d(void *dm_void)
+static void phydm_set_power_trim_rf_8721d(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2013,7 +2013,7 @@ void phydm_set_power_trim_rf_8721d(void *dm_void)
 	odm_set_rf_reg(dm, RF_PATH_A, RF_0xee, BIT(19), 0);
 }
 
-void phydm_get_set_power_trim_offset_8721d(void *dm_void)
+static void phydm_get_set_power_trim_offset_8721d(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2089,7 +2089,7 @@ void phydm_get_set_power_trim_offset_8721d(void *dm_void)
 	}
 }
 
-void phydm_get_set_pa_bias_offset_8721d(void *dm_void)
+static void phydm_get_set_pa_bias_offset_8721d(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2126,7 +2126,7 @@ void phydm_get_set_pa_bias_offset_8721d(void *dm_void)
 #endif
 }
 
-void phydm_get_thermal_trim_offset_8197g(void *dm_void)
+static void phydm_get_thermal_trim_offset_8197g(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2153,7 +2153,7 @@ void phydm_get_thermal_trim_offset_8197g(void *dm_void)
 		       power_trim_info->thermal);
 }
 
-void phydm_set_power_trim_offset_8197g(void *dm_void)
+static void phydm_set_power_trim_offset_8197g(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2187,7 +2187,7 @@ void phydm_set_power_trim_offset_8197g(void *dm_void)
 
 }
 
-void phydm_get_set_power_trim_offset_8197g(void *dm_void)
+static void phydm_get_set_power_trim_offset_8197g(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2228,7 +2228,7 @@ void phydm_get_set_power_trim_offset_8197g(void *dm_void)
 	}
 }
 
-void phydm_get_set_pa_bias_offset_8197g(void *dm_void)
+static void phydm_get_set_pa_bias_offset_8197g(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2258,7 +2258,7 @@ void phydm_get_set_pa_bias_offset_8197g(void *dm_void)
 	}
 }
 
-void phydm_get_set_lna_offset_8197g(void *dm_void)
+static void phydm_get_set_lna_offset_8197g(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2294,7 +2294,7 @@ void phydm_get_set_lna_offset_8197g(void *dm_void)
 	}
 }
 
-void phydm_set_lna_trim_offset_8197g(void *dm_void, u8 path, u8 cg_cs, u8 enable)
+static void phydm_set_lna_trim_offset_8197g(void *dm_void, u8 path, u8 cg_cs, u8 enable)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *trim = &dm->power_trim_data;
@@ -2322,7 +2322,7 @@ void phydm_set_lna_trim_offset_8197g(void *dm_void, u8 path, u8 cg_cs, u8 enable
 }
 
 
-void phydm_get_thermal_trim_offset_8710c(void *dm_void)
+static void phydm_get_thermal_trim_offset_8710c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2350,7 +2350,7 @@ void phydm_get_thermal_trim_offset_8710c(void *dm_void)
 		       power_trim_info->thermal);
 }
 
-void phydm_set_power_trim_offset_8710c(void *dm_void)
+static void phydm_set_power_trim_offset_8710c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2370,7 +2370,7 @@ void phydm_set_power_trim_offset_8710c(void *dm_void)
 	odm_set_rf_reg(dm, RF_PATH_A, RF_0xef, BIT(18), 0);
 }
 
-void phydm_get_set_power_trim_offset_8710c(void *dm_void)
+static void phydm_get_set_power_trim_offset_8710c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2408,7 +2408,7 @@ void phydm_get_set_power_trim_offset_8710c(void *dm_void)
 	}
 }
 
-void phydm_get_set_pa_bias_offset_8710c(void *dm_void)
+static void phydm_get_set_pa_bias_offset_8710c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2432,7 +2432,7 @@ void phydm_get_set_pa_bias_offset_8710c(void *dm_void)
 	}
 }
 
-void phydm_get_thermal_trim_offset_8814b(void *dm_void)
+static void phydm_get_thermal_trim_offset_8814b(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;
@@ -2485,7 +2485,7 @@ s8 phydm_get_tssi_trim_de(void *dm_void, u8 path)
 		return 0;	
 }
 
-void phydm_do_new_kfree(void *dm_void)
+static void phydm_do_new_kfree(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -2539,7 +2539,7 @@ void phydm_do_new_kfree(void *dm_void)
 	}
 }
 
-void phydm_set_kfree_to_rf(void *dm_void, u8 e_rf_path, u8 data)
+static void phydm_set_kfree_to_rf(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -2671,7 +2671,7 @@ s8 phydm_get_multi_thermal_offset(void *dm_void, u8 path)
 		return 0;
 }
 
-void phydm_do_kfree(void *dm_void, u8 channel_to_sw)
+static void phydm_do_kfree(void *dm_void, u8 channel_to_sw)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *pwrtrim = &dm->power_trim_data;

--- a/hal/phydm/halrf/halrf_psd.c
+++ b/hal/phydm/halrf/halrf_psd.c
@@ -20,7 +20,7 @@
 #include "mp_precomp.h"
 #include "phydm_precomp.h"
 
-u64 _sqrt(u64 x)
+static u64 _sqrt(u64 x)
 {
 	u64 i = 0;
 	u64 j = (x >> 1) + 1;
@@ -41,7 +41,7 @@ u64 _sqrt(u64 x)
 	return j;
 }
 
-u32 halrf_get_psd_data(
+static u32 halrf_get_psd_data(
 	struct dm_struct *dm,
 	u32 point)
 {
@@ -214,7 +214,7 @@ void halrf_psd(
 		odm_set_bb_reg(dm, psd_reg, 0x3000, avg_org);
 }
 
-void backup_bb_register(struct dm_struct *dm, u32 *bb_backup, u32 *backup_bb_reg, u32 counter)
+static void backup_bb_register(struct dm_struct *dm, u32 *bb_backup, u32 *backup_bb_reg, u32 counter)
 {
 	u32 i ;
 
@@ -222,7 +222,7 @@ void backup_bb_register(struct dm_struct *dm, u32 *bb_backup, u32 *backup_bb_reg
 		bb_backup[i] = odm_get_bb_reg(dm, backup_bb_reg[i], MASKDWORD);
 }
 
-void restore_bb_register(struct dm_struct *dm, u32 *bb_backup, u32 *backup_bb_reg, u32 counter)
+static void restore_bb_register(struct dm_struct *dm, u32 *bb_backup, u32 *backup_bb_reg, u32 counter)
 {
 	u32 i ;
 
@@ -232,7 +232,7 @@ void restore_bb_register(struct dm_struct *dm, u32 *bb_backup, u32 *backup_bb_re
 
 
 
-void _halrf_psd_iqk_init(struct dm_struct *dm)
+static void _halrf_psd_iqk_init(struct dm_struct *dm)
 {
 	odm_set_bb_reg(dm, 0x1b04, MASKDWORD, 0x0);
 	odm_set_bb_reg(dm, 0x1b08, MASKDWORD, 0x80);
@@ -261,7 +261,7 @@ void _halrf_psd_iqk_init(struct dm_struct *dm)
 }
 
 
-u32 halrf_get_iqk_psd_data(
+static u32 halrf_get_iqk_psd_data(
 	struct dm_struct *dm,
 	u32 point)
 {
@@ -337,7 +337,7 @@ u32 halrf_get_iqk_psd_data(
 	return psd_val;
 }
 
-void halrf_iqk_psd(
+static void halrf_iqk_psd(
 	struct dm_struct *dm,
 	u32 point,
 	u32 start_point,

--- a/hal/phydm/halrf/rtl8822c/halrf_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_8822c.c
@@ -154,7 +154,7 @@ void odm_tx_pwr_track_set_pwr8822c(void *dm_void, enum pwrtrack_method method,
 	}
 }
 
-void get_delta_swing_table_8822c(void *dm_void,
+static void get_delta_swing_table_8822c(void *dm_void,
 	u8 **temperature_up_a,
 	u8 **temperature_down_a,
 	u8 **temperature_up_b,
@@ -197,7 +197,7 @@ void get_delta_swing_table_8822c(void *dm_void,
 	}
 }
 
-void _phy_aac_calibrate_8822c(struct dm_struct *dm)
+static void _phy_aac_calibrate_8822c(struct dm_struct *dm)
 {
 #if 1
 	u32 cnt = 0;
@@ -220,7 +220,7 @@ void _phy_aac_calibrate_8822c(struct dm_struct *dm)
 	RF_DBG(dm, DBG_RF_IQK, "[AACK]AACK end!!!!!!!\n");
 #endif
 }
-void _phy_rt_calibrate_8822c(struct dm_struct *dm)
+static void _phy_rt_calibrate_8822c(struct dm_struct *dm)
 {
 	RF_DBG(dm, DBG_RF_IQK, "[RTK]RTK start!!!!!!!\n");
 	odm_set_rf_reg(dm, RF_PATH_A, 0xcc, RFREGOFFSETMASK, 0x0f000);
@@ -230,7 +230,7 @@ void _phy_rt_calibrate_8822c(struct dm_struct *dm)
 	RF_DBG(dm, DBG_RF_IQK, "[RTK]RTK end!!!!!!!\n");
 }
 
-void halrf_reload_bp_8822c(struct dm_struct *dm, u32 *bp_reg, u32 *bp)
+static void halrf_reload_bp_8822c(struct dm_struct *dm, u32 *bp_reg, u32 *bp)
 {
 	u32 i;
 
@@ -238,7 +238,7 @@ void halrf_reload_bp_8822c(struct dm_struct *dm, u32 *bp_reg, u32 *bp)
 		odm_write_4byte(dm, bp_reg[i], bp[i]);
 }
 
-void halrf_reload_bprf_8822c(struct dm_struct *dm, u32 *bp_reg, u32 bp[][2])
+static void halrf_reload_bprf_8822c(struct dm_struct *dm, u32 *bp_reg, u32 bp[][2])
 {
 	u32 i;
 
@@ -250,7 +250,7 @@ void halrf_reload_bprf_8822c(struct dm_struct *dm, u32 *bp_reg, u32 bp[][2])
 	}
 }
 
-void halrf_bp_8822c(struct dm_struct *dm, u32 *bp_reg, u32 *bp)
+static void halrf_bp_8822c(struct dm_struct *dm, u32 *bp_reg, u32 *bp)
 {
 	u32 i;
 
@@ -258,7 +258,7 @@ void halrf_bp_8822c(struct dm_struct *dm, u32 *bp_reg, u32 *bp)
 		bp[i] = odm_read_4byte(dm, bp_reg[i]);
 }
 
-void halrf_bprf_8822c(struct dm_struct *dm, u32 *bp_reg, u32 bp[][2])
+static void halrf_bprf_8822c(struct dm_struct *dm, u32 *bp_reg, u32 bp[][2])
 {
 	u32 i;
 
@@ -270,7 +270,7 @@ void halrf_bprf_8822c(struct dm_struct *dm, u32 *bp_reg, u32 bp[][2])
 	}
 }
 
-void halrf_swap_8822c(struct dm_struct *dm, u32 *v1, u32 *v2)
+static void halrf_swap_8822c(struct dm_struct *dm, u32 *v1, u32 *v2)
 {
 	u32 temp;
 
@@ -279,7 +279,7 @@ void halrf_swap_8822c(struct dm_struct *dm, u32 *v1, u32 *v2)
 	*v2 = temp;
 }
 
-void halrf_bubble_8822c(struct dm_struct *dm, u32 *v1, u32 *v2)
+static void halrf_bubble_8822c(struct dm_struct *dm, u32 *v1, u32 *v2)
 {
 	u32 temp;
 
@@ -294,7 +294,7 @@ void halrf_bubble_8822c(struct dm_struct *dm, u32 *v1, u32 *v2)
 	}
 }
 
-void halrf_b_sort_8822c(struct dm_struct *dm, u32 *iv, u32 *qv)
+static void halrf_b_sort_8822c(struct dm_struct *dm, u32 *iv, u32 *qv)
 {
 	u32 temp;
 	u32 i, j;
@@ -308,7 +308,7 @@ void halrf_b_sort_8822c(struct dm_struct *dm, u32 *iv, u32 *qv)
 	}
 }
 
-void halrf_minmax_compare_8822c(struct dm_struct *dm, u32 value, u32 *min,
+static void halrf_minmax_compare_8822c(struct dm_struct *dm, u32 value, u32 *min,
 				u32 *max)
 {
 	if (value >= 0x200) {
@@ -337,7 +337,7 @@ void halrf_minmax_compare_8822c(struct dm_struct *dm, u32 value, u32 *min,
 	}
 }
 
-boolean halrf_compare_8822c(struct dm_struct *dm, u32 value)
+static boolean halrf_compare_8822c(struct dm_struct *dm, u32 value)
 {
 	boolean fail = false;
 
@@ -351,7 +351,7 @@ boolean halrf_compare_8822c(struct dm_struct *dm, u32 value)
 	return fail;
 }
 
-void halrf_mode_8822c(struct dm_struct *dm, u32 *i_value, u32 *q_value)
+static void halrf_mode_8822c(struct dm_struct *dm, u32 *i_value, u32 *q_value)
 {
 	u32 iv[SN], qv[SN], im[SN], qm[SN], temp, temp1, temp2;
 	u32 p, m, t;
@@ -511,7 +511,7 @@ void halrf_mode_8822c(struct dm_struct *dm, u32 *i_value, u32 *q_value)
 #endif
 }
 
-void halrf_biask_backup_8822c(void *dm_void)
+static void halrf_biask_backup_8822c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_dack_info *dack = &dm->dack_info;
@@ -522,7 +522,7 @@ void halrf_biask_backup_8822c(void *dm_void)
 	dack->biask_d[1][1]= (u8)odm_get_bb_reg(dm, 0x453c, 0x1ff8);
 }
 
-void halrf_dck_backup_8822c(void *dm_void)
+static void halrf_dck_backup_8822c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_dack_info *dack = &dm->dack_info;
@@ -537,7 +537,7 @@ void halrf_dck_backup_8822c(void *dm_void)
 	dack->dck_d[1][1][0] = (u8)odm_get_bb_reg(dm, 0x41d8, 0xf0000000);
 	dack->dck_d[1][1][1] = (u8)odm_get_bb_reg(dm, 0x41dc, 0xf);
 }
-void halrf_dack_backup_8822c(void *dm_void)
+static void halrf_dack_backup_8822c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_dack_info *dack = &dm->dack_info;
@@ -589,7 +589,7 @@ void halrf_dack_backup_8822c(void *dm_void)
 	halrf_biask_backup_8822c(dm);
 }
 
-void halrf_biask_restore_8822c(void *dm_void)
+static void halrf_biask_restore_8822c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_dack_info *dack = &dm->dack_info;
@@ -600,7 +600,7 @@ void halrf_biask_restore_8822c(void *dm_void)
 	odm_set_bb_reg(dm, 0x41cc, 0x1ff8000, dack->biask_d[1][1]);
 }
 
-void halrf_dck_restore_8822c(void *dm_void)
+static void halrf_dck_restore_8822c(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_dack_info *dack = &dm->dack_info;
@@ -816,7 +816,7 @@ void halrf_dack_restore_8822c(void *dm_void)
 	halrf_biask_restore_8822c(dm);
 }
 
-void halrf_polling_check(void *dm_void, u32 add, u32 bmask, u32 data)
+static void halrf_polling_check(void *dm_void, u32 add, u32 bmask, u32 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 c = 0;
@@ -1400,7 +1400,7 @@ void halrf_rxdck_8822c(void *dm_void)
 	odm_set_rf_reg(dm, RF_PATH_A, 0x0, RFREGOFFSETMASK, 0x3ffff);
 	odm_set_rf_reg(dm, RF_PATH_B, 0x0, RFREGOFFSETMASK, 0x3ffff);
 }
-void _phy_x2_calibrate_8822c(struct dm_struct *dm)
+static void _phy_x2_calibrate_8822c(struct dm_struct *dm)
 {
 	RF_DBG(dm, DBG_RF_IQK, "[X2K]X2K start!!!!!!!\n");
 	/*X2K*/
@@ -1487,7 +1487,7 @@ void phy_set_rf_path_switch_8822c(void *adapter, boolean is_main)
 }
 
 #if ((DM_ODM_SUPPORT_TYPE & ODM_AP) || (DM_ODM_SUPPORT_TYPE == ODM_CE))
-boolean _phy_query_rf_path_switch_8822c(struct dm_struct *dm)
+static boolean _phy_query_rf_path_switch_8822c(struct dm_struct *dm)
 #else
 boolean _phy_query_rf_path_switch_8822c(void *adapter)
 #endif
@@ -1505,7 +1505,7 @@ boolean _phy_query_rf_path_switch_8822c(void *adapter)
 }
 
 #if ((DM_ODM_SUPPORT_TYPE & ODM_AP) || (DM_ODM_SUPPORT_TYPE == ODM_CE))
-boolean phy_query_rf_path_switch_8822c(struct dm_struct *dm)
+static boolean phy_query_rf_path_switch_8822c(struct dm_struct *dm)
 #else
 boolean phy_query_rf_path_switch_8822c(void *adapter)
 #endif

--- a/hal/phydm/halrf/rtl8822c/halrf_dpk_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_dpk_8822c.c
@@ -152,7 +152,7 @@ void btc_set_gnt_wl_bt_8822c(
 	}
 }
 
-void _backup_mac_bb_registers_8822c(
+static void _backup_mac_bb_registers_8822c(
 	struct dm_struct *dm,
 	u32 *reg,
 	u32 *reg_backup,
@@ -169,7 +169,7 @@ void _backup_mac_bb_registers_8822c(
 	}
 }
 
-void _backup_rf_registers_8822c(
+static void _backup_rf_registers_8822c(
 	struct dm_struct *dm,
 	u32 *rf_reg,
 	u32 rf_reg_backup[][2])
@@ -190,7 +190,7 @@ void _backup_rf_registers_8822c(
 	}
 }
 
-void _reload_mac_bb_registers_8822c(
+static void _reload_mac_bb_registers_8822c(
 	struct dm_struct *dm,
 	u32 *reg,
 	u32 *reg_backup,
@@ -215,7 +215,7 @@ void _reload_mac_bb_registers_8822c(
 	odm_set_bb_reg(dm, R_0x1bd4, 0x000000f0, 0x4); /*force CLK off for power saving*/
 }
 
-void _reload_rf_registers_8822c(
+static void _reload_rf_registers_8822c(
 	struct dm_struct *dm,
 	u32 *rf_reg,
 	u32 rf_reg_backup[][2])
@@ -245,7 +245,7 @@ void _reload_rf_registers_8822c(
 #endif
 }
 
-void _dpk_information_8822c(
+static void _dpk_information_8822c(
 	struct dm_struct *dm)
 {
 	struct dm_dpk_info *dpk_info = &dm->dpk_info;
@@ -269,7 +269,7 @@ void _dpk_information_8822c(
 	       dpk_info->dpk_bw == 3 ? "20M" : (dpk_info->dpk_bw == 2 ? "40M" : "80M"));
 }
 
-void _dpk_rxbb_dc_cal_8822c(
+static void _dpk_rxbb_dc_cal_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -283,7 +283,7 @@ void _dpk_rxbb_dc_cal_8822c(
 	odm_set_rf_reg(dm, (enum rf_path)path, 0x92, RFREG_MASK, 0x84800);
 }
 
-u8 _dpk_dc_corr_check_8822c(
+static u8 _dpk_dc_corr_check_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -323,7 +323,7 @@ u8 _dpk_dc_corr_check_8822c(
 
 }
 
-void _dpk_tx_pause_8822c(
+static void _dpk_tx_pause_8822c(
 	struct dm_struct *dm)
 {
 	u8 reg_rf0_a, reg_rf0_b;
@@ -345,7 +345,7 @@ void _dpk_tx_pause_8822c(
 	RF_DBG(dm, DBG_RF_DPK, "[DPK] Tx pause!!\n");
 }
 
-void _dpk_mac_bb_setting_8822c(
+static void _dpk_mac_bb_setting_8822c(
 	struct dm_struct *dm)
 {
 	struct dm_dpk_info *dpk_info = &dm->dpk_info;
@@ -386,7 +386,7 @@ void _dpk_mac_bb_setting_8822c(
 	RF_DBG(dm, DBG_RF_DPK, "[DPK] MAC/BB setting for DPK mode\n");
 }
 
-void _dpk_manual_txagc_8822c(
+static void _dpk_manual_txagc_8822c(
 	struct dm_struct *dm,
 	boolean is_manual)
 {
@@ -394,7 +394,7 @@ void _dpk_manual_txagc_8822c(
 	odm_set_bb_reg(dm, R_0x41a4, BIT(7), is_manual);
 }
 
-void _dpk_set_txagc_8822c(
+static void _dpk_set_txagc_8822c(
 	struct dm_struct *dm)
 {
 	odm_set_bb_reg(dm, R_0x18a0, 0x007C0000, 0x1f);
@@ -403,7 +403,7 @@ void _dpk_set_txagc_8822c(
 	odm_set_bb_reg(dm, 0x41e8, 0x0001F000, 0x1f);
 }
 
-void _dpk_afe_setting_8822c(
+static void _dpk_afe_setting_8822c(
 	struct dm_struct *dm,
 	boolean is_do_dpk)
 {
@@ -519,7 +519,7 @@ void _dpk_afe_setting_8822c(
 	}
 }
 
-void _dpk_pre_setting_8822c(
+static void _dpk_pre_setting_8822c(
 	struct dm_struct *dm)
 {
 	struct dm_dpk_info *dpk_info = &dm->dpk_info;
@@ -543,7 +543,7 @@ void _dpk_pre_setting_8822c(
 	odm_set_bb_reg(dm, R_0x1be8, MASKDWORD, 0x775f5347);
 }
 
-u32 _dpk_rf_setting_8822c(
+static u32 _dpk_rf_setting_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -658,7 +658,7 @@ u32 _dpk_rf_setting_8822c(
 	return ori_txbb & 0x1f;
 }
 
-u8 _dpk_one_shot_8822c(
+static u8 _dpk_one_shot_8822c(
 	struct dm_struct *dm,
 	u8 path,
 	u8 action)
@@ -731,7 +731,7 @@ u8 _dpk_one_shot_8822c(
 	return result;
 }
 
-u16 _dpk_dgain_read_8822c(
+static u16 _dpk_dgain_read_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -747,7 +747,7 @@ u16 _dpk_dgain_read_8822c(
 	return dgain;
 }
 
-u8 _dpk_thermal_read_8822c(
+static u8 _dpk_thermal_read_8822c(
 	void *dm_void,
 	u8 path)
 {
@@ -762,7 +762,7 @@ u8 _dpk_thermal_read_8822c(
 	return (u8)odm_get_rf_reg(dm, (enum rf_path)path, RF_0x42, 0x0007e);
 }
 
-u32 _dpk_pas_read_8822c(
+static u32 _dpk_pas_read_8822c(
 	struct dm_struct *dm,
 	u8 path,
 	u8 action)
@@ -818,7 +818,7 @@ u32 _dpk_pas_read_8822c(
 	return i_val*i_val + q_val*q_val;
 }
 
-u8 _dpk_gainloss_result_8822c(
+static u8 _dpk_gainloss_result_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -836,7 +836,7 @@ u8 _dpk_gainloss_result_8822c(
 	return result;
 }
 
-u8 _dpk_agc_chk_8822c(
+static u8 _dpk_agc_chk_8822c(
 	struct dm_struct *dm,
 	u8 path,
 	u8 limited_pga,
@@ -891,7 +891,7 @@ u8 _dpk_agc_chk_8822c(
 
 }
 
-u8 _dpk_pas_agc_8822c(
+static u8 _dpk_pas_agc_8822c(
 	struct dm_struct *dm,
 	u8 path,
 	u8 gain_only,
@@ -1017,7 +1017,7 @@ u8 _dpk_pas_agc_8822c(
 	return tmp_txbb;
 }
 
-boolean _dpk_coef_iq_check_8822c(
+static boolean _dpk_coef_iq_check_8822c(
 	struct dm_struct *dm,
 	u16 coef_i,
 	u16 coef_q)
@@ -1029,7 +1029,7 @@ boolean _dpk_coef_iq_check_8822c(
 		return 0;
 }
 
-u32 _dpk_coef_transfer_8822c(
+static u32 _dpk_coef_transfer_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1116,7 +1116,7 @@ void _dpk_get_coef_8822c(
 
 }
 
-u8 _dpk_coef_read_8822c(
+static u8 _dpk_coef_read_8822c(
 	void *dm_void,
 	u8 path)
 {
@@ -1138,7 +1138,7 @@ u8 _dpk_coef_read_8822c(
 	return result;
 }
 
-void _dpk_coef_write_8822c(
+static void _dpk_coef_write_8822c(
 	void *dm_void,
 	u8 path,
 	u8 result)
@@ -1175,7 +1175,7 @@ void _dpk_coef_write_8822c(
 	}
 }
 
-void _dpk_coef1_read_8822c(
+static void _dpk_coef1_read_8822c(
 	void *dm_void,
 	u8 path)
 {
@@ -1248,7 +1248,7 @@ void _dpk_coef1_read_8822c(
 	odm_set_bb_reg(dm, 0x1b04 + path * 0x58, 0xf0000000, 0x0); /*disable manual coef*/
 }
 
-void _dpk_coef_default_8822c(
+static void _dpk_coef_default_8822c(
 	void *dm_void,
 	u8 path)
 {
@@ -1278,7 +1278,7 @@ void _dpk_coef_default_8822c(
 	}
 }
 
-void _dpk_fill_result_8822c(
+static void _dpk_fill_result_8822c(
 	void *dm_void,
 	u32 dpk_txagc,
 	u8 path,
@@ -1303,7 +1303,7 @@ void _dpk_fill_result_8822c(
 	_dpk_coef_write_8822c(dm, path, result);
 }
 
-u32 _dpk_gainloss_8822c(
+static u32 _dpk_gainloss_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -1368,7 +1368,7 @@ u32 _dpk_gainloss_8822c(
 	return tx_agc;
 }
 
-u8 _dpk_by_path_8822c(
+static u8 _dpk_by_path_8822c(
 	struct dm_struct *dm,
 	u32 tx_agc,
 	u8 path)
@@ -1422,7 +1422,7 @@ u8 _dpk_by_path_8822c(
 	return result;
 }
 
-void _dpk_cal_gs_8822c(
+static void _dpk_cal_gs_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -1507,7 +1507,7 @@ void _dpk_cal_gs_8822c(
 
 }
 
-void _dpk_cal_coef1_8822c(
+static void _dpk_cal_coef1_8822c(
 	struct dm_struct *dm)
 {
 	struct dm_dpk_info *dpk_info = &dm->dpk_info;
@@ -1559,7 +1559,7 @@ void _dpk_cal_coef1_8822c(
 	}
  }
 
-void _dpk_on_8822c(
+static void _dpk_on_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -1595,7 +1595,7 @@ void dpk_coef_read_8822c(
 	RF_DBG(dm, DBG_RF_DPK, "[DPK] ========= Coef Read Finish =========\n");
 }
 
-u8 _dpk_check_fail_8822c(
+static u8 _dpk_check_fail_8822c(
 	struct dm_struct *dm,
 	boolean is_fail,
 	u32 dpk_txagc,
@@ -1617,7 +1617,7 @@ u8 _dpk_check_fail_8822c(
 	return result;
 }
 
-void _dpk_result_reset_8822c(
+static void _dpk_result_reset_8822c(
 	struct dm_struct *dm)
 {
 	struct dm_dpk_info *dpk_info = &dm->dpk_info;
@@ -1648,7 +1648,7 @@ void _dpk_result_reset_8822c(
 	}
 }
 
-void _dpk_calibrate_8822c(
+static void _dpk_calibrate_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -1679,7 +1679,7 @@ void _dpk_calibrate_8822c(
 
 }
 
-void _dpk_path_select_8822c(
+static void _dpk_path_select_8822c(
 	struct dm_struct *dm)
 {
 	struct dm_dpk_info *dpk_info = &dm->dpk_info;
@@ -1697,7 +1697,7 @@ void _dpk_path_select_8822c(
 	_dpk_cal_coef1_8822c(dm);
 }
 
-void _dpk_result_summary_8822c(
+static void _dpk_result_summary_8822c(
 	struct dm_struct *dm)
 {
 	struct dm_dpk_info *dpk_info = &dm->dpk_info;
@@ -1726,7 +1726,7 @@ void _dpk_result_summary_8822c(
 
 }
 
-void _dpk_reload_data_8822c(
+static void _dpk_reload_data_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1783,7 +1783,7 @@ u8 dpk_reload_8822c(
 	return dpk_info->is_reload;
 }
 
-void _dpk_by_fw_8822c(
+static void _dpk_by_fw_8822c(
 	struct dm_struct *dm)
 {
 	enum hal_status status = HAL_STATUS_FAILURE;
@@ -1798,7 +1798,7 @@ void _dpk_by_fw_8822c(
 		RF_DBG(dm, DBG_RF_DPK, "[DPK] FW DPK Trigger Fail!!!\n");
 }
 
-void _dpk_force_bypass_8822c(
+static void _dpk_force_bypass_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1814,7 +1814,7 @@ void _dpk_force_bypass_8822c(
 	RF_DBG(dm, DBG_RF_DPK, "[DPK] S1 DPK bypass !!!\n");
 }
 
-void _rx_dc_cal_8822c(
+static void _rx_dc_cal_8822c(
 	struct dm_struct *dm)
 {
 	u32 bb_reg_backup[7];

--- a/hal/phydm/halrf/rtl8822c/halrf_iqk_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_iqk_8822c.c
@@ -37,7 +37,7 @@
 #if (RTL8822C_SUPPORT == 1)
 
 #if 1
-boolean
+static boolean
 _iqk_check_cal_8822c(
 	struct dm_struct *dm,
 	u8 path,
@@ -80,7 +80,7 @@ _iqk_check_cal_8822c(
 	return false;
 }
 
-void _iqk_idft(struct dm_struct *dm)
+static void _iqk_idft(struct dm_struct *dm)
 {
 
 	odm_write_4byte(dm, 0x1b00, 0x8);
@@ -100,7 +100,7 @@ void _iqk_idft(struct dm_struct *dm)
 	odm_set_bb_reg(dm, R_0x1b20, BIT(31) | BIT(30), 0x0);	
 }
 
-void _iqk_rx_cfir_check_8822c(struct dm_struct *dm, u8 t)
+static void _iqk_rx_cfir_check_8822c(struct dm_struct *dm, u8 t)
 {
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
 	u8 j;
@@ -132,7 +132,7 @@ void _iqk_rx_cfir_check_8822c(struct dm_struct *dm, u8 t)
 }
 
 
-void _iqk_get_rxcfir_8822c(void *dm_void, u8 path, u8 t)
+static void _iqk_get_rxcfir_8822c(void *dm_void, u8 path, u8 t)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
@@ -166,7 +166,7 @@ void _iqk_get_rxcfir_8822c(void *dm_void, u8 path, u8 t)
 //	odm_set_bb_reg(dm, R_0x1bd8, MASKDWORD, 0x0);
 }
 
-void _iqk_reload_rxcfir_8822c(struct dm_struct *dm, u8 path)
+static void _iqk_reload_rxcfir_8822c(struct dm_struct *dm, u8 path)
 {
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
 #if 1
@@ -212,7 +212,7 @@ void _iqk_reload_rxcfir_8822c(struct dm_struct *dm, u8 path)
 #endif
 }
 
-void _iqk_rx_cfir_8822c(struct dm_struct *dm, u8 path)
+static void _iqk_rx_cfir_8822c(struct dm_struct *dm, u8 path)
 {
 
 	u32 xym_tmp[6], cfir_tmp[3];
@@ -237,7 +237,7 @@ void _iqk_rx_cfir_8822c(struct dm_struct *dm, u8 path)
 		path, cfir_tmp[0], cfir_tmp[1], cfir_tmp[2]);
 }
 
-void _iqk_tx_cfir_8822c(struct dm_struct *dm, u8 path)
+static void _iqk_tx_cfir_8822c(struct dm_struct *dm, u8 path)
 {
 	u32 xym_tmp[6], cfir_tmp[3];
 	u32 i;
@@ -263,7 +263,7 @@ void _iqk_tx_cfir_8822c(struct dm_struct *dm, u8 path)
 
 #endif
 
-u8 _iqk_get_efuse_thermal_8822c(
+static u8 _iqk_get_efuse_thermal_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -281,7 +281,7 @@ u8 _iqk_get_efuse_thermal_8822c(
 
 
 /*---------------------------Define Local Constant---------------------------*/
-void phydm_get_read_counter_8822c(struct dm_struct *dm)
+static void phydm_get_read_counter_8822c(struct dm_struct *dm)
 {
 	u32 counter = 0x0;
 
@@ -396,7 +396,7 @@ void iqk_info_rsvd_page_8822c(
 		*buf_size = IQK_INFO_RSVD_LEN_8822C;
 }
 
-void _iqk_information_8822c(
+static void _iqk_information_8822c(
 	struct dm_struct *dm)
 {
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
@@ -420,7 +420,7 @@ void _iqk_information_8822c(
 }
 
 
-boolean _iqk_xym_read_8822c(struct dm_struct *dm, u8 path)
+static boolean _iqk_xym_read_8822c(struct dm_struct *dm, u8 path)
 {
 	u32 i = 0x0;
 	u32 xym = 0x0;
@@ -535,7 +535,7 @@ _iqk_btc_write_indirect_reg_8822c(struct dm_struct *dm, u16 reg_addr,
 	}
 }
 
-void _iqk_set_gnt_wl_high_8822c(struct dm_struct *dm)
+static void _iqk_set_gnt_wl_high_8822c(struct dm_struct *dm)
 {
 	u32 val = 0;
 	u8 state = 0x1;
@@ -546,7 +546,7 @@ void _iqk_set_gnt_wl_high_8822c(struct dm_struct *dm)
 	//_iqk_btc_write_indirect_reg_8822c(dm, 0x38, 0x0300, val); /*0x38[9:8]*/
 }
 
-void _iqk_set_gnt_bt_low_8822c(struct dm_struct *dm)
+static void _iqk_set_gnt_bt_low_8822c(struct dm_struct *dm)
 {
 	u32 val = 0;
 	u8 state = 0x0, sw_control = 0x1;
@@ -557,7 +557,7 @@ void _iqk_set_gnt_bt_low_8822c(struct dm_struct *dm)
 	//_iqk_btc_write_indirect_reg_8822c(dm, 0x38, 0x0c00, val); /*0x38[11:10]*/
 }
 
-void _iqk_set_gnt_wl_gnt_bt_8822c(struct dm_struct *dm, boolean beforeK)
+static void _iqk_set_gnt_wl_gnt_bt_8822c(struct dm_struct *dm, boolean beforeK)
 {
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
 
@@ -571,7 +571,7 @@ void _iqk_set_gnt_wl_gnt_bt_8822c(struct dm_struct *dm, boolean beforeK)
 
 
 
-void _iqk_nctl_8822c(struct dm_struct *dm)
+static void _iqk_nctl_8822c(struct dm_struct *dm)
 {
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]==========IQK NCTL!!!!!========\n");
 	//odm_write_4byte(dm 0x1CD0, 0x7 [31:28]);	
@@ -2405,7 +2405,7 @@ void _iqk_nctl_8822c(struct dm_struct *dm)
 }
 
 
-void _iqk_cal_path_off_8822c(struct dm_struct *dm)
+static void _iqk_cal_path_off_8822c(struct dm_struct *dm)
 {
 	u8 path;
 
@@ -2418,7 +2418,7 @@ void _iqk_cal_path_off_8822c(struct dm_struct *dm)
 	}
 }
 
-void _iqk_con_tx_8822c(
+static void _iqk_con_tx_8822c(
 	struct dm_struct *dm,
 	boolean is_contx)
 {
@@ -2439,7 +2439,7 @@ void _iqk_con_tx_8822c(
 	}
 }
 
-void _iqk_rf_set_check_8822c(
+static void _iqk_rf_set_check_8822c(
 	struct dm_struct *dm,
 	u8 path,
 	u16 add,
@@ -2459,7 +2459,7 @@ void _iqk_rf_set_check_8822c(
 	}
 }
 
-void _iqk_rf0xb0_workaround_8822c(
+static void _iqk_rf0xb0_workaround_8822c(
 	struct dm_struct *dm)
 {
 	/*add 0xb8 control for the bad phase noise after switching channel*/
@@ -2467,7 +2467,7 @@ void _iqk_rf0xb0_workaround_8822c(
 	odm_set_rf_reg(dm, (enum rf_path)0x0, RF_0xb8, RFREGOFFSETMASK, 0x80a00);
 }
 
-void _iqk_fill_iqk_report_8822c(
+static void _iqk_fill_iqk_report_8822c(
 	void *dm_void,
 	u8 ch)
 {
@@ -2492,7 +2492,7 @@ void _iqk_fill_iqk_report_8822c(
 	
 }
 
-void _iqk_fail_count_8822c(
+static void _iqk_fail_count_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -2514,7 +2514,7 @@ void _iqk_fail_count_8822c(
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]All/Fail = %d %d\n", dm->n_iqk_cnt, dm->n_iqk_fail_cnt);
 }
 
-void _iqk_iqk_fail_report_8822c(
+static void _iqk_iqk_fail_report_8822c(
 	struct dm_struct *dm)
 {
 	u32 tmp1bf0 = 0x0;
@@ -2538,7 +2538,7 @@ void _iqk_iqk_fail_report_8822c(
 	}
 }
 
-void _iqk_backup_mac_bb_8822c(
+static void _iqk_backup_mac_bb_8822c(
 	struct dm_struct *dm,
 	u32 *MAC_backup,
 	u32 *BB_backup,
@@ -2557,7 +2557,7 @@ void _iqk_backup_mac_bb_8822c(
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]BackupMacBB Success!!!!\n"); 
 }
 
-void _iqk_backup_rf_8822c(
+static void _iqk_backup_rf_8822c(
 	struct dm_struct *dm,
 	u32 RF_backup[][SS_8822C],
 	u32 *backup_rf_reg)
@@ -2573,7 +2573,7 @@ void _iqk_backup_rf_8822c(
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]BackupRF Success!!!!\n"); 
 }
 
-void _iqk_agc_bnd_int_8822c(
+static void _iqk_agc_bnd_int_8822c(
 	struct dm_struct *dm)
 {
 	return;
@@ -2587,7 +2587,7 @@ void _iqk_agc_bnd_int_8822c(
 #endif
 }
 
-void _iqk_bb_reset_8822c(
+static void _iqk_bb_reset_8822c(
 	struct dm_struct *dm)
 {
 	boolean cca_ing = false;
@@ -2624,7 +2624,7 @@ void _iqk_bb_reset_8822c(
 		}
 	}
 }
-void _iqk_bb_for_dpk_setting_8822c(struct dm_struct *dm)
+static void _iqk_bb_for_dpk_setting_8822c(struct dm_struct *dm)
 {
 	odm_set_bb_reg(dm, R_0x1e24, BIT(17), 0x1);
 	odm_set_bb_reg(dm, R_0x1cd0, BIT(28), 0x1);
@@ -2645,7 +2645,7 @@ void _iqk_bb_for_dpk_setting_8822c(struct dm_struct *dm)
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]_iqk_bb_for_dpk_setting_8822c!!!!\n");
 }
 
-void _iqk_rf_setting_8822c(struct dm_struct *dm)
+static void _iqk_rf_setting_8822c(struct dm_struct *dm)
 {	
 	odm_set_bb_reg(dm, 0x1bb8, BIT(20), 0x0);
 	/*TxIQK mode S0,RF0x00[19:16]=0x4*/
@@ -2694,7 +2694,7 @@ void _iqk_rf_setting_8822c(struct dm_struct *dm)
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]_iqk_rf_setting_8822c RF01!!!!\n");
 }
 
-void _iqk_set_afe_8822c(struct dm_struct *dm)
+static void _iqk_set_afe_8822c(struct dm_struct *dm)
 {
 	odm_set_bb_reg(dm, 0x1830, BIT(30), 0x0);
 	odm_set_bb_reg(dm, 0x1860, 0xfffff000, 0xf0001);
@@ -2708,7 +2708,7 @@ void _iqk_set_afe_8822c(struct dm_struct *dm)
 }
 
 
-void _iqk_afe_setting_8822c(
+static void _iqk_afe_setting_8822c(
 	struct dm_struct *dm,
 	boolean do_iqk)
 {
@@ -2847,7 +2847,7 @@ void _iqk_afe_setting_8822c(
 	}
 }
 
-void _iqk_restore_mac_bb_8822c(
+static void _iqk_restore_mac_bb_8822c(
 	struct dm_struct *dm,
 	u32 *MAC_backup,
 	u32 *BB_backup,
@@ -2888,7 +2888,7 @@ void _iqk_restore_mac_bb_8822c(
 	/*	RF_DBG(dm, DBG_RF_IQK, "[IQK]RestoreMacBB Success!!!!\n"); */
 }
 
-void _iqk_restore_rf_8822c(
+static void _iqk_restore_rf_8822c(
 	struct dm_struct *dm,
 	u32 *rf_reg,
 	u32 temp[][SS_8822C])
@@ -2913,7 +2913,7 @@ void _iqk_restore_rf_8822c(
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]RestoreRF Success!!!!\n"); 
 }
 
-void _iqk_backup_iqk_8822c(
+static void _iqk_backup_iqk_8822c(
 	struct dm_struct *dm,
 	u8 step,
 	u8 path)
@@ -2966,7 +2966,7 @@ void _iqk_backup_iqk_8822c(
 	}
 }
 
-void _iqk_reload_iqk_setting_8822c(
+static void _iqk_reload_iqk_setting_8822c(
 	struct dm_struct *dm,
 	u8 ch,
 	u8 reload_idx /*1: reload TX, 2: reload LO, TX, RX*/
@@ -3034,7 +3034,7 @@ void _iqk_reload_iqk_setting_8822c(
 #endif
 }
 
-boolean
+static boolean
 _iqk_reload_iqk_8822c(
 	struct dm_struct *dm,
 	boolean reset)
@@ -3065,7 +3065,7 @@ _iqk_reload_iqk_8822c(
 	return iqk_info->is_reload;
 }
 
-void _iqk_rfe_setting_8822c(
+static void _iqk_rfe_setting_8822c(
 	struct dm_struct *dm,
 	boolean ext_pa_on)
 {
@@ -3096,7 +3096,7 @@ void _iqk_rfe_setting_8822c(
 #endif
 }
 
-void _iqk_setrf_bypath_8822c(
+static void _iqk_setrf_bypath_8822c(
 	struct dm_struct *dm)
 {
 	u8 path;
@@ -3104,7 +3104,7 @@ void _iqk_setrf_bypath_8822c(
 
 	/*TBD*/
 }
-void _iqk_rf_direct_access_8822c(
+static void _iqk_rf_direct_access_8822c(
 	struct dm_struct *dm,
 	u8 path,
 	boolean direct_access)
@@ -3130,7 +3130,7 @@ void _iqk_rf_direct_access_8822c(
 	*/
 }
 
-void _iqk_bbtx_path_8822c(
+static void _iqk_bbtx_path_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -3150,7 +3150,7 @@ void _iqk_bbtx_path_8822c(
 	odm_set_bb_reg(dm, 0x824, 0xf0000, temp2);
 }
 
-void _iqk_iqk_mode_8822c(
+static void _iqk_iqk_mode_8822c(
 	struct dm_struct *dm,
 	boolean is_iqkmode)
 {
@@ -3163,7 +3163,7 @@ void _iqk_iqk_mode_8822c(
 		odm_set_bb_reg(dm, 0x1cd0, BIT(31), 0x0);	
 }
 
-void _iqk_macbb_8822c(
+static void _iqk_macbb_8822c(
 	struct dm_struct *dm)
 {
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
@@ -3204,7 +3204,7 @@ void _iqk_macbb_8822c(
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]_iqk_macbb_8822c!!!!\n");
 }
 
-void _iqk_lok_setting_8822c(
+static void _iqk_lok_setting_8822c(
 	struct dm_struct *dm,
 	u8 path,
 	u8 idac_bs)
@@ -3266,7 +3266,7 @@ void _iqk_lok_setting_8822c(
 		odm_set_bb_reg(dm, 0x1b2c, 0xfff, 0x38);
 }
 
-void _iqk_reload_lok_setting_8822c(
+static void _iqk_reload_lok_setting_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -3295,7 +3295,7 @@ void _iqk_reload_lok_setting_8822c(
 #endif
 }
 
-void _iqk_txk_setting_8822c(
+static void _iqk_txk_setting_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -3348,7 +3348,7 @@ void _iqk_txk_setting_8822c(
 		odm_set_bb_reg(dm, 0x1b2c, 0xfff, 0x38);
 }
 
-void _iqk_lok_for_rxk_setting_8822c(
+static void _iqk_lok_for_rxk_setting_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -3414,7 +3414,7 @@ void _iqk_lok_for_rxk_setting_8822c(
 
 //static u8 wlg_lna[5] = {0x0, 0x1, 0x2, 0x3, 0x5};
 //static u8 wla_lna[5] = {0x0, 0x1, 0x3, 0x4, 0x5};
-void _iqk_rxk1_setting_8822c(
+static void _iqk_rxk1_setting_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -3447,7 +3447,7 @@ void _iqk_rxk1_setting_8822c(
 		odm_set_bb_reg(dm, 0x1b2c, 0xfff, 0x038);
 }
 
-void _iqk_rxk2_setting_8822c(
+static void _iqk_rxk2_setting_8822c(
 	struct dm_struct *dm,
 	u8 path,
 	boolean is_gs)
@@ -3492,7 +3492,7 @@ void _iqk_rxk2_setting_8822c(
 
 
 
-void
+static void
 _iqk_set_lok_lut_8822c(
 	struct dm_struct *dm,
 	u8 path)
@@ -3521,7 +3521,7 @@ _iqk_set_lok_lut_8822c(
 #endif
 }
 
-boolean
+static boolean
 _iqk_rx_iqk_gain_search_fail_8822c(
 	struct dm_struct *dm,
 	u8 path,
@@ -3617,7 +3617,7 @@ return fail;
 	
 }
 
-boolean
+static boolean
 _lok_check_8822c(void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3643,7 +3643,7 @@ _lok_check_8822c(void *dm_void, u8 path)
 }
 
 
-boolean
+static boolean
 _lok_one_shot_8822c(
 	void *dm_void,
 	u8 path,
@@ -3711,7 +3711,7 @@ _lok_one_shot_8822c(
 	return LOK_notready;
 }
 
-boolean
+static boolean
 _iqk_one_shot_8822c(
 	void *dm_void,
 	u8 path,
@@ -3825,7 +3825,7 @@ _iqk_one_shot_8822c(
 	return fail;
 }
 
-boolean
+static boolean
 _iqk_rx_iqk_by_path_8822c(
 	void *dm_void,
 	u8 path)
@@ -3956,7 +3956,7 @@ _iqk_rx_iqk_by_path_8822c(
 #endif
 }
 
-void _iqk_lok_tune_8822c(void *dm_void, u8 path)
+static void _iqk_lok_tune_8822c(void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 idac_bs = 0x4;
@@ -3976,7 +3976,7 @@ void _iqk_lok_tune_8822c(void *dm_void, u8 path)
 	}
 }
 
-boolean
+static boolean
 _lok_load_default_8822c(void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4029,7 +4029,7 @@ _lok_load_default_8822c(void *dm_void, u8 path)
 
 }
 
-void _iqk_iqk_by_path_8822c(
+static void _iqk_iqk_by_path_8822c(
 	void *dm_void,
 	boolean segment_iqk)
 {
@@ -4221,7 +4221,7 @@ void _iqk_iqk_by_path_8822c(
 
 }
 
-void _iqk_dpd_in_sel(
+static void _iqk_dpd_in_sel(
 	struct dm_struct *dm,
 	u8 input)
 {
@@ -4235,7 +4235,7 @@ void _iqk_dpd_in_sel(
 
 }
 
-void _iqk_start_iqk_8822c(
+static void _iqk_start_iqk_8822c(
 	struct dm_struct *dm,
 	boolean segment_iqk)
 {
@@ -4302,7 +4302,7 @@ void _iq_calibrate_8822c_init(
 
 }
 
-boolean
+static boolean
 _iqk_rximr_rxk1_test_8822c(
 	struct dm_struct *dm,
 	u8 path,
@@ -4324,7 +4324,7 @@ _iqk_rximr_rxk1_test_8822c(
 	return fail;
 }
 
-u32 _iqk_tximr_selfcheck_8822c(
+static u32 _iqk_tximr_selfcheck_8822c(
 	void *dm_void,
 	u8 tone_index,
 	u8 path)
@@ -4386,7 +4386,7 @@ u32 _iqk_tximr_selfcheck_8822c(
 	return tximr;
 }
 
-void _iqk_start_tximr_test_8822c(
+static void _iqk_start_tximr_test_8822c(
 	struct dm_struct *dm,
 	u8 imr_limit)
 {
@@ -4406,7 +4406,7 @@ void _iqk_start_tximr_test_8822c(
 	}
 }
 
-u32 _iqk_rximr_selfcheck_8822c(
+static u32 _iqk_rximr_selfcheck_8822c(
 	void *dm_void,
 	u32 tone_index,
 	u8 path,
@@ -4517,7 +4517,7 @@ u32 _iqk_rximr_selfcheck_8822c(
 	return rximr;
 }
 
-void _iqk_rximr_test_8822c(
+static void _iqk_rximr_test_8822c(
 	struct dm_struct *dm,
 	u8 path,
 	u8 imr_limit)
@@ -4616,7 +4616,7 @@ void _iqk_rximr_test_8822c(
 	}
 }
 
-void _iqk_start_rximr_test_8822c(
+static void _iqk_start_rximr_test_8822c(
 	struct dm_struct *dm,
 	u8 imr_limit)
 {
@@ -4626,7 +4626,7 @@ void _iqk_start_rximr_test_8822c(
 		_iqk_rximr_test_8822c(dm, path, imr_limit);
 }
 
-void _iqk_start_imr_test_8822c(
+static void _iqk_start_imr_test_8822c(
 	void *dm_void)
 {
 	u8 imr_limit;
@@ -4646,7 +4646,7 @@ void _iqk_start_imr_test_8822c(
 
 
 
-void _phy_iq_calibrate_8822c(
+static void _phy_iq_calibrate_8822c(
 	struct dm_struct *dm,
 	boolean reset,
 	boolean segment_iqk)
@@ -4722,7 +4722,7 @@ void _phy_iq_calibrate_8822c(
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]==========IQK end!!!!!==========\n");
 }
 
-void _check_fwiqk_done_8822c(struct dm_struct *dm)
+static void _check_fwiqk_done_8822c(struct dm_struct *dm)
 {
 	u32 counter = 0x0;
 #if 1
@@ -4742,7 +4742,7 @@ void _check_fwiqk_done_8822c(struct dm_struct *dm)
 }
 
 
-void _phy_iq_calibrate_by_fw_8822c(
+static void _phy_iq_calibrate_by_fw_8822c(
 	void *dm_void,
 	u8 clear,
 	u8 segment_iqk)
@@ -4907,7 +4907,7 @@ void iqk_set_cfir_8822c(void *dm_void, u8 idx, u8 path, boolean debug)
 }
 
 
-void iqk_clean_cfir_8822c(void *dm_void, u8 mode, u8 path)
+static void iqk_clean_cfir_8822c(void *dm_void, u8 mode, u8 path)
 {	
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;	

--- a/hal/phydm/halrf/rtl8822c/halrf_tssi_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_tssi_8822c.c
@@ -36,7 +36,7 @@
 
 #if (RTL8822C_SUPPORT == 1)
 
-void _backup_bb_registers_8822c(
+static void _backup_bb_registers_8822c(
 	void *dm_void,
 	u32 *reg,
 	u32 *reg_backup,
@@ -53,7 +53,7 @@ void _backup_bb_registers_8822c(
 	}
 }
 
-void _reload_bb_registers_8822c(
+static void _reload_bb_registers_8822c(
 	void *dm_void,
 	u32 *reg,
 	u32 *reg_backup,
@@ -72,7 +72,7 @@ void _reload_bb_registers_8822c(
 
 
 
-u8 _halrf_driver_rate_to_tssi_rate_8822c(
+static u8 _halrf_driver_rate_to_tssi_rate_8822c(
 	void *dm_void, u8 rate)
 {
 	u8 tssi_rate = 0;
@@ -112,7 +112,7 @@ u8 _halrf_driver_rate_to_tssi_rate_8822c(
 	return tssi_rate;
 }
 
-u8 _halrf_tssi_rate_to_driver_rate_8822c(
+static u8 _halrf_tssi_rate_to_driver_rate_8822c(
 	void *dm_void, u8 rate)
 {
 	u8 driver_rate = 0;
@@ -152,7 +152,7 @@ u8 _halrf_tssi_rate_to_driver_rate_8822c(
 	return driver_rate;
 }
 
-void _halrf_calculate_txagc_codeword_8822c(
+static void _halrf_calculate_txagc_codeword_8822c(
 	void *dm_void, u16 *tssi_value,  s16 *txagc_value)
 {
 #if 0
@@ -173,7 +173,7 @@ void _halrf_calculate_txagc_codeword_8822c(
 #endif
 }
 
-u32 _halrf_get_efuse_tssi_offset_8822c(
+static u32 _halrf_get_efuse_tssi_offset_8822c(
 	void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -232,7 +232,7 @@ u32 _halrf_get_efuse_tssi_offset_8822c(
 	return offset;
 }
 
-s8 _halrf_get_kfree_tssi_offset_8822c(
+static s8 _halrf_get_kfree_tssi_offset_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -355,7 +355,7 @@ void halrf_calculate_tssi_codeword_8822c(
 
 }
 
-void _halrf_calculate_set_thermal_codeword_8822c(
+static void _halrf_calculate_set_thermal_codeword_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -590,7 +590,7 @@ void _halrf_calculate_set_thermal_codeword_8822c(
 		odm_set_bb_reg(dm, R_0x1c20, 0x03f00000, 0x0);
 }
 
-void _halrf_set_txagc_codeword_8822c(
+static void _halrf_set_txagc_codeword_8822c(
 	void *dm_void, s16 *tssi_value)
 {
 #if 0
@@ -634,7 +634,7 @@ void halrf_set_tssi_codeword_8822c(
 	}
 }
 
-void _halrf_set_efuse_kfree_offset_8822c(
+static void _halrf_set_efuse_kfree_offset_8822c(
 	void *dm_void)
 {
 #if 0
@@ -687,7 +687,7 @@ void _halrf_set_efuse_kfree_offset_8822c(
 #endif
 }
 
-void _halrf_tssi_init_8822c(
+static void _halrf_tssi_init_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -702,7 +702,7 @@ void _halrf_tssi_init_8822c(
 	/*_halrf_set_efuse_kfree_offset_8822c(dm);*/
 }
 
-void _halrf_tssi_8822c(
+static void _halrf_tssi_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -979,7 +979,7 @@ void _halrf_tssi_8822c(
 	}
 }
 
-u32 _halrf_tssi_channel_to_index(
+static u32 _halrf_tssi_channel_to_index(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1000,7 +1000,7 @@ u32 _halrf_tssi_channel_to_index(
 	return idx;
 }
 
-void _halrf_tssi_scan_8822c(
+static void _halrf_tssi_scan_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1165,7 +1165,7 @@ void _halrf_tssi_scan_8822c(
 	}
 }
 
-void _halrf_thermal_init_8822c(
+static void _halrf_thermal_init_8822c(
 	void *dm_void)
 {
 #if 0
@@ -1182,7 +1182,7 @@ void _halrf_thermal_init_8822c(
 #endif
 }
 
-void _halrf_tssi_reload_dck_8822c(
+static void _halrf_tssi_reload_dck_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1209,7 +1209,7 @@ void _halrf_tssi_reload_dck_8822c(
 	}	
 }
 
-void _halrf_bsort_8822c(
+static void _halrf_bsort_8822c(
 	void *dm_void,
 	s8 *array,
 	u8 array_length)
@@ -2431,7 +2431,7 @@ void halrf_tssi_get_kfree_efuse_8822c(
 
 }
 
-void halrf_tssi_set_de_8822c(
+static void halrf_tssi_set_de_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;

--- a/hal/phydm/halrf/rtl8822c/halrf_txgapk_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_txgapk_8822c.c
@@ -36,7 +36,7 @@
 
 #if (RTL8822C_SUPPORT == 1)
 
-void _halrf_txgapk_backup_bb_registers_8822c(
+static void _halrf_txgapk_backup_bb_registers_8822c(
 	void *dm_void,
 	u32 *reg,
 	u32 *reg_backup,
@@ -53,7 +53,7 @@ void _halrf_txgapk_backup_bb_registers_8822c(
 	}
 }
 
-void _halrf_txgapk_reload_bb_registers_8822c(
+static void _halrf_txgapk_reload_bb_registers_8822c(
 	void *dm_void,
 	u32 *reg,
 	u32 *reg_backup,
@@ -70,7 +70,7 @@ void _halrf_txgapk_reload_bb_registers_8822c(
 	}
 }
 
-void _halrf_txgapk_bb_dpk_8822c(
+static void _halrf_txgapk_bb_dpk_8822c(
 	void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -100,7 +100,7 @@ void _halrf_txgapk_bb_dpk_8822c(
 	odm_set_bb_reg(dm, R_0x1a00, 0x00000003, 0x2);
 }
 
-void _halrf_txgapk_afe_dpk_8822c(
+static void _halrf_txgapk_afe_dpk_8822c(
 	void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -150,7 +150,7 @@ void _halrf_txgapk_afe_dpk_8822c(
 	}
 }
 
-void _halrf_txgapk_afe_dpk_restore_8822c(
+static void _halrf_txgapk_afe_dpk_restore_8822c(
 	void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -196,7 +196,7 @@ void _halrf_txgapk_afe_dpk_restore_8822c(
 	}
 }
 
-void _halrf_txgapk_bb_dpk_restore_8822c(
+static void _halrf_txgapk_bb_dpk_restore_8822c(
 	void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -240,7 +240,7 @@ void _halrf_txgapk_bb_dpk_restore_8822c(
 
 }
 
-void _halrf_txgapk_write_gain_bb_table_8822c(
+static void _halrf_txgapk_write_gain_bb_table_8822c(
 	void *dm_void)
 {
 #if 0
@@ -329,7 +329,7 @@ void _halrf_txgapk_write_gain_bb_table_8822c(
 #endif
 }
 
-void _halrf_txgapk_calculate_offset_8822c(
+static void _halrf_txgapk_calculate_offset_8822c(
 	void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -513,7 +513,7 @@ void _halrf_txgapk_calculate_offset_8822c(
 	_halrf_txgapk_reload_bb_registers_8822c(dm, bb_reg, bb_reg_backup, backup_num);
 }
 
-void _halrf_txgapk_rf_restore_8822c(
+static void _halrf_txgapk_rf_restore_8822c(
 	void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -533,7 +533,7 @@ void _halrf_txgapk_rf_restore_8822c(
 	}
 }
 
-u32 _halrf_txgapk_calculat_tx_gain_8822c(
+static u32 _halrf_txgapk_calculat_tx_gain_8822c(
 	void *dm_void, u32 original_tx_gain, s8 offset)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -570,7 +570,7 @@ u32 _halrf_txgapk_calculat_tx_gain_8822c(
 	return modify_tx_gain;
 }
 
-void _halrf_txgapk_write_tx_gain_8822c(
+static void _halrf_txgapk_write_tx_gain_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -657,7 +657,7 @@ void _halrf_txgapk_write_tx_gain_8822c(
 	}
 }
 
-void _halrf_txgapk_disable_power_trim_8822c(
+static void _halrf_txgapk_disable_power_trim_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -672,7 +672,7 @@ void _halrf_txgapk_disable_power_trim_8822c(
 
 }
 
-void _halrf_txgapk_enable_power_trim_8822c(
+static void _halrf_txgapk_enable_power_trim_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;

--- a/hal/phydm/phydm.c
+++ b/hal/phydm/phydm.c
@@ -44,7 +44,7 @@ const u16 phy_rate_table[] = {
 	26, 52, 78, 104, 156, 208, 234, 260, 312, 360 /*@4ss MCS0~9*/
 };
 
-void phydm_traffic_load_decision(void *dm_void)
+static void phydm_traffic_load_decision(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 shift = 0;
@@ -115,7 +115,7 @@ void phydm_traffic_load_decision(void *dm_void)
 	#endif
 }
 
-void phydm_cck_new_agc_chk(struct dm_struct *dm)
+static void phydm_cck_new_agc_chk(struct dm_struct *dm)
 {
 	u32 new_agc_addr = 0x0;
 
@@ -139,7 +139,7 @@ void phydm_cck_new_agc_chk(struct dm_struct *dm)
 }
 
 /*select 3 or 4 bit LNA */
-void phydm_cck_lna_bit_num_chk(struct dm_struct *dm)
+static void phydm_cck_lna_bit_num_chk(struct dm_struct *dm)
 {
 	boolean report_type = 0;
 	#if (RTL8192E_SUPPORT)
@@ -184,7 +184,7 @@ void phydm_cck_lna_bit_num_chk(struct dm_struct *dm)
 		  dm->cck_agc_report_type);
 }
 
-void phydm_init_cck_setting(struct dm_struct *dm)
+static void phydm_init_cck_setting(struct dm_struct *dm)
 {
 	u32 reg_tmp = 0;
 	u32 mask_tmp = 0;
@@ -227,7 +227,7 @@ void phydm_init_hw_info_by_rfe(struct dm_struct *dm)
 }
 #endif
 
-void phydm_common_info_self_init(struct dm_struct *dm)
+static void phydm_common_info_self_init(struct dm_struct *dm)
 {
 	u32 reg_tmp = 0;
 	u32 mask_tmp = 0;
@@ -362,7 +362,7 @@ void phydm_iot_patch_id_update(void *dm_void, u32 iot_idx, boolean en)
 	}
 }
 
-void phydm_cmn_sta_info_update(void *dm_void, u8 macid)
+static void phydm_cmn_sta_info_update(void *dm_void, u8 macid)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct cmn_sta_info *sta = dm->phydm_sta_info[macid];
@@ -390,7 +390,7 @@ void phydm_cmn_sta_info_update(void *dm_void, u8 macid)
 	ra->is_noisy = dm->noisy_decision;
 }
 
-void phydm_common_info_self_update(struct dm_struct *dm)
+static void phydm_common_info_self_update(struct dm_struct *dm)
 {
 	u8 sta_cnt = 0, num_active_client = 0;
 	u32 i, one_entry_macid = 0;
@@ -481,7 +481,7 @@ void phydm_common_info_self_update(struct dm_struct *dm)
 	dm->pre_is_linked = dm->is_linked;
 }
 
-void phydm_common_info_self_reset(struct dm_struct *dm)
+static void phydm_common_info_self_reset(struct dm_struct *dm)
 {
 	struct odm_phy_dbg_info		*dbg_t = &dm->phy_dbg_info;
 
@@ -524,7 +524,7 @@ phydm_get_structure(struct dm_struct *dm, u8 structure_type)
 	return structure;
 }
 
-void phydm_phy_info_update(struct dm_struct *dm)
+static void phydm_phy_info_update(struct dm_struct *dm)
 {
 #if (RTL8822B_SUPPORT)
 	if (dm->support_ic_type == ODM_RTL8822B)
@@ -532,7 +532,7 @@ void phydm_phy_info_update(struct dm_struct *dm)
 #endif
 }
 
-void phydm_hw_setting(struct dm_struct *dm)
+static void phydm_hw_setting(struct dm_struct *dm)
 {
 #if (RTL8821A_SUPPORT)
 	if (dm->support_ic_type & ODM_RTL8821)
@@ -575,7 +575,7 @@ void phydm_hw_setting(struct dm_struct *dm)
 }
 
 __odm_func__
-boolean phydm_chk_bb_rf_pkg_set_valid(struct dm_struct *dm)
+static boolean phydm_chk_bb_rf_pkg_set_valid(struct dm_struct *dm)
 {
 	boolean valid = true;
 
@@ -906,7 +906,7 @@ u64 phydm_supportability_init_win(
 #endif
 
 #if (DM_ODM_SUPPORT_TYPE & (ODM_CE))
-u64 phydm_supportability_init_ce(void *dm_void)
+static u64 phydm_supportability_init_ce(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u64 support_ability = 0;
@@ -1602,7 +1602,7 @@ void phydm_fwoffload_ability_clear(struct dm_struct *dm,
 		  dm->fw_offload_ability);
 }
 
-void phydm_supportability_init(void *dm_void)
+static void phydm_supportability_init(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u64 support_ability;
@@ -1646,7 +1646,7 @@ void phydm_supportability_init(void *dm_void)
 		  dm->support_ic_type, *dm->mp_mode, dm->support_ability);
 }
 
-void phydm_rfe_init(void *dm_void)
+static void phydm_rfe_init(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -2228,7 +2228,7 @@ void phydm_pause_dm_by_asso_pkt(struct dm_struct *dm,
 	}
 }
 
-u8 phydm_stop_dm_watchdog_check(void *dm_void)
+static u8 phydm_stop_dm_watchdog_check(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 

--- a/hal/phydm/phydm_adaptivity.c
+++ b/hal/phydm/phydm_adaptivity.c
@@ -148,7 +148,7 @@ void phydm_check_adaptivity(void *dm_void)
 
 #endif
 
-void phydm_dig_up_bound_lmt_en(void *dm_void)
+static void phydm_dig_up_bound_lmt_en(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_adaptivity_struct *adapt = &dm->adaptivity;
@@ -176,7 +176,7 @@ void phydm_dig_up_bound_lmt_en(void *dm_void)
 		  adapt->igi_up_bound_lmt_cnt);
 }
 
-void phydm_set_edcca_threshold(void *dm_void, s8 H2L, s8 L2H)
+static void phydm_set_edcca_threshold(void *dm_void, s8 H2L, s8 L2H)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -192,7 +192,7 @@ void phydm_set_edcca_threshold(void *dm_void, s8 H2L, s8 L2H)
 	}
 }
 
-void phydm_mac_edcca_state(void *dm_void, enum phydm_mac_edcca_type state)
+static void phydm_mac_edcca_state(void *dm_void, enum phydm_mac_edcca_type state)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -210,7 +210,7 @@ void phydm_mac_edcca_state(void *dm_void, enum phydm_mac_edcca_type state)
 	PHYDM_DBG(dm, DBG_ADPTVTY, "EDCCA enable state = %d\n", state);
 }
 
-void phydm_search_pwdb_lower_bound(void *dm_void)
+static void phydm_search_pwdb_lower_bound(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_adaptivity_struct *adapt = &dm->adaptivity;
@@ -287,7 +287,7 @@ void phydm_search_pwdb_lower_bound(void *dm_void)
 	phydm_set_edcca_threshold(dm, 0x7f, 0x7f); /*resume to no link state*/
 }
 
-boolean phydm_re_search_condition(void *dm_void)
+static boolean phydm_re_search_condition(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_adaptivity_struct *adaptivity = &dm->adaptivity;
@@ -299,7 +299,7 @@ boolean phydm_re_search_condition(void *dm_void)
 		return false;
 }
 
-void phydm_set_l2h_th_ini(void *dm_void)
+static void phydm_set_l2h_th_ini(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -323,7 +323,7 @@ void phydm_set_l2h_th_ini(void *dm_void)
 	}
 }
 
-void phydm_set_l2h_th_ini_carrier_sense(void *dm_void)
+static void phydm_set_l2h_th_ini_carrier_sense(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -333,7 +333,7 @@ void phydm_set_l2h_th_ini_carrier_sense(void *dm_void)
 		dm->th_l2h_ini = 10; /*@ -50dBm*/
 }
 
-void phydm_set_forgetting_factor(void *dm_void)
+static void phydm_set_forgetting_factor(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -345,7 +345,7 @@ void phydm_set_forgetting_factor(void *dm_void)
 		odm_set_bb_reg(dm, R_0x8a0, BIT(1) | BIT(0), 0);
 }
 
-void phydm_edcca_decision_opt(void *dm_void)
+static void phydm_edcca_decision_opt(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -447,7 +447,7 @@ void phydm_set_edcca_val(void *dm_void, u32 *val_buf, u8 val_len)
 	phydm_set_edcca_threshold(dm, (s8)val_buf[1], (s8)val_buf[0]);
 }
 
-boolean phydm_edcca_abort(void *dm_void)
+static boolean phydm_edcca_abort(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_adaptivity_struct *adapt = &dm->adaptivity;
@@ -480,7 +480,7 @@ boolean phydm_edcca_abort(void *dm_void)
 	return false;
 }
 
-void phydm_edcca_thre_calc_jgr3(void *dm_void)
+static void phydm_edcca_thre_calc_jgr3(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;
@@ -508,7 +508,7 @@ void phydm_edcca_thre_calc_jgr3(void *dm_void)
 	phydm_set_edcca_threshold(dm, adapt->th_h2l, adapt->th_l2h);
 }
 
-void phydm_edcca_thre_calc(void *dm_void)
+static void phydm_edcca_thre_calc(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;

--- a/hal/phydm/phydm_adc_sampling.c
+++ b/hal/phydm/phydm_adc_sampling.c
@@ -192,7 +192,7 @@ phydm_la_mv_data_2_tx_buffer(void *dm_void)
 
 #ifdef PHYDM_IC_JGR3_SERIES_SUPPORT
 
-void phydm_la_bb_adv_reset_jgr3(void *dm_void)
+static void phydm_la_bb_adv_reset_jgr3(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct rt_adcsmp *smp = &dm->adcsmp;
@@ -202,7 +202,7 @@ void phydm_la_bb_adv_reset_jgr3(void *dm_void)
 
 }
 
-void phydm_la_bb_adv_trig_setting_jgr3(void *dm_void)
+static void phydm_la_bb_adv_trig_setting_jgr3(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct rt_adcsmp *smp = &dm->adcsmp;
@@ -254,7 +254,7 @@ void phydm_la_bb_adv_trig_setting_jgr3(void *dm_void)
 	}
 }
 
-void phydm_la_bb_adv_cmd_show_jgr3(void *dm_void, u32 *_used,
+static void phydm_la_bb_adv_cmd_show_jgr3(void *dm_void, u32 *_used,
 				   char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -273,7 +273,7 @@ void phydm_la_bb_adv_cmd_show_jgr3(void *dm_void, u32 *_used,
 		 adv->la_and4_mask, adv->la_and4_bitmap, adv->la_and4_inv);
 }
 
-void phydm_la_bb_adv_cmd_jgr3(void *dm_void, char input[][16], u32 *_used,
+static void phydm_la_bb_adv_cmd_jgr3(void *dm_void, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -333,7 +333,7 @@ void phydm_la_bb_adv_cmd_jgr3(void *dm_void, char input[][16], u32 *_used,
 	phydm_la_bb_adv_cmd_show_jgr3(dm, _used, output, _out_len);
 }
 
-void phydm_la_cmd_fast_jgr3(void *dm_void, char input[][16], u32 *_used,
+static void phydm_la_cmd_fast_jgr3(void *dm_void, char input[][16], u32 *_used,
 			    char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -642,7 +642,7 @@ void phydm_la_cmd_fast_jgr3(void *dm_void, char input[][16], u32 *_used,
 
 #endif
 
-void
+static void
 phydm_la_buffer_print(void *dm_void, char input[][16], u32 *_used,
 		      char *output, u32 *_out_len)
 {
@@ -720,7 +720,7 @@ phydm_la_buffer_print(void *dm_void, char input[][16], u32 *_used,
 	pr_debug("Dump_End\n\n");
 }
 
-void
+static void
 phydm_la_buffer_release(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -733,7 +733,7 @@ phydm_la_buffer_release(void *dm_void)
 	}
 }
 
-boolean
+static boolean
 phydm_la_buffer_allocate(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -767,7 +767,7 @@ phydm_la_buffer_allocate(void *dm_void)
 	return ret;
 }
 
-void phydm_la_access_tx_pkt_buf(void *dm_void, u32 addr, u32 buff_idx)
+static void phydm_la_access_tx_pkt_buf(void *dm_void, u32 addr, u32 buff_idx)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct rt_adcsmp *smp = &dm->adcsmp;
@@ -812,7 +812,7 @@ void phydm_la_access_tx_pkt_buf(void *dm_void, u32 addr, u32 buff_idx)
 		pr_debug("%08x%08x\n", data_h, data_l);
 }
 
-void phydm_la_get_tx_pkt_buf(void *dm_void)
+static void phydm_la_get_tx_pkt_buf(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct rt_adcsmp *smp = &dm->adcsmp;
@@ -897,7 +897,7 @@ void phydm_la_get_tx_pkt_buf(void *dm_void)
 	pr_debug("Dump_End\n");
 }
 
-void phydm_la_set_trig_src(void *dm_void, u8 la_trig_mode)
+static void phydm_la_set_trig_src(void *dm_void, u8 la_trig_mode)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 reg = (dm->support_ic_type == ODM_RTL8192F) ? R_0x7f0 : R_0x7c0;
@@ -908,7 +908,7 @@ void phydm_la_set_trig_src(void *dm_void, u8 la_trig_mode)
 		odm_set_mac_reg(dm, reg, BIT(3), 0);
 }
 
-void phydm_la_set_mac_iq_dump(void *dm_void, boolean impossible_trig_condi)
+static void phydm_la_set_mac_iq_dump(void *dm_void, boolean impossible_trig_condi)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct rt_adcsmp *smp = &dm->adcsmp;
@@ -975,7 +975,7 @@ void phydm_la_set_mac_iq_dump(void *dm_void, boolean impossible_trig_condi)
 	#endif
 }
 
-void phydm_la_set_bb_dbg_port(void *dm_void, boolean impossible_trig_condi)
+static void phydm_la_set_bb_dbg_port(void *dm_void, boolean impossible_trig_condi)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct rt_adcsmp *smp = &dm->adcsmp;
@@ -1022,7 +1022,7 @@ void phydm_la_set_bb_dbg_port(void *dm_void, boolean impossible_trig_condi)
 	}
 }
 
-void phydm_la_set_bb(void *dm_void)
+static void phydm_la_set_bb(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct rt_adcsmp *smp = &dm->adcsmp;
@@ -1110,7 +1110,7 @@ void phydm_la_set_bb(void *dm_void)
 	}
 }
 
-void phydm_la_set_mac_trigger_time(void *dm_void, u32 trigger_time_mu_sec)
+static void phydm_la_set_mac_trigger_time(void *dm_void, u32 trigger_time_mu_sec)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 time_unit_num = 0;
@@ -1155,7 +1155,7 @@ void phydm_la_set_mac_trigger_time(void *dm_void, u32 trigger_time_mu_sec)
 	}
 }
 
-void phydm_la_set_buff_mode(void *dm_void, enum la_buff_mode mode)
+static void phydm_la_set_buff_mode(void *dm_void, enum la_buff_mode mode)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct rt_adcsmp *smp = &dm->adcsmp;
@@ -1228,7 +1228,7 @@ void phydm_la_set_buff_mode(void *dm_void, enum la_buff_mode mode)
 		 smp->smp_number_max);
 }
 
-void phydm_la_adc_smp_start(void *dm_void)
+static void phydm_la_adc_smp_start(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct rt_adcsmp *smp = &dm->adcsmp;

--- a/hal/phydm/phydm_api.c
+++ b/hal/phydm/phydm_api.c
@@ -343,7 +343,7 @@ void phydm_config_cck_tx_path(void *dm_void, enum bb_path path)
 #endif
 }
 
-void phydm_config_trx_path_v2(void *dm_void, char input[][16], u32 *_used,
+static void phydm_config_trx_path_v2(void *dm_void, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
 #if (RTL8822B_SUPPORT || RTL8197F_SUPPORT || RTL8192F_SUPPORT ||\
@@ -406,7 +406,7 @@ void phydm_config_trx_path_v2(void *dm_void, char input[][16], u32 *_used,
 #endif
 }
 
-void phydm_config_trx_path_v1(void *dm_void, char input[][16], u32 *_used,
+static void phydm_config_trx_path_v1(void *dm_void, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
 #if (RTL8192E_SUPPORT || RTL8812A_SUPPORT)
@@ -827,7 +827,7 @@ void phydm_set_ext_switch(void *dm_void, u32 ext_ant_switch)
 #endif
 }
 
-void phydm_csi_mask_enable(void *dm_void, u32 enable)
+static void phydm_csi_mask_enable(void *dm_void, u32 enable)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	boolean en = false;
@@ -851,7 +851,7 @@ void phydm_csi_mask_enable(void *dm_void, u32 enable)
 	}
 }
 
-void phydm_clean_all_csi_mask(void *dm_void)
+static void phydm_clean_all_csi_mask(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -890,7 +890,7 @@ void phydm_clean_all_csi_mask(void *dm_void)
 	}
 }
 
-void phydm_set_csi_mask(void *dm_void, u32 tone_idx_tmp, u8 tone_direction)
+static void phydm_set_csi_mask(void *dm_void, u32 tone_idx_tmp, u8 tone_direction)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 byte_offset = 0, bit_offset = 0;
@@ -949,7 +949,7 @@ void phydm_set_csi_mask(void *dm_void, u32 tone_idx_tmp, u8 tone_direction)
 		  (tone_idx_tmp + tone_num_shift), target_reg, reg_tmp_value);
 }
 
-void phydm_set_nbi_reg(void *dm_void, u32 tone_idx_tmp, u32 bw)
+static void phydm_set_nbi_reg(void *dm_void, u32 tone_idx_tmp, u32 bw)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	/*tone_idx X 10*/
@@ -1044,7 +1044,7 @@ void phydm_nbi_enable(void *dm_void, u32 enable)
 	}
 }
 
-u8 phydm_find_fc(void *dm_void, u32 channel, u32 bw, u32 second_ch, u32 *fc_in)
+static u8 phydm_find_fc(void *dm_void, u32 channel, u32 bw, u32 second_ch, u32 *fc_in)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 fc = *fc_in;
@@ -1119,7 +1119,7 @@ u8 phydm_find_fc(void *dm_void, u32 channel, u32 bw, u32 second_ch, u32 *fc_in)
 	return PHYDM_SET_SUCCESS;
 }
 
-u8 phydm_find_intf_distance(void *dm_void, u32 bw, u32 fc, u32 f_interference,
+static u8 phydm_find_intf_distance(void *dm_void, u32 bw, u32 fc, u32 f_interference,
 			    u32 *tone_idx_tmp_in)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1201,7 +1201,7 @@ u8 phydm_csi_mask_setting(void *dm_void, u32 enable, u32 ch, u32 bw,
 }
 
 #ifdef PHYDM_IC_JGR3_SERIES_SUPPORT
-u8 phydm_find_intf_distance_jgr3(void *dm_void, u32 bw, u32 fc,
+static u8 phydm_find_intf_distance_jgr3(void *dm_void, u32 bw, u32 fc,
 				 u32 f_interference, u32 *tone_idx_tmp_in)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1411,7 +1411,7 @@ void phydm_set_csi_mask_jgr3(void *dm_void, u32 tone_idx_tmp, u8 tone_direction,
 	odm_set_bb_reg(dm, R_0x1ee8, 0x3, 0x0);
 }
 
-void phydm_nbi_reset_jgr3(void *dm_void)
+static void phydm_nbi_reset_jgr3(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -1713,7 +1713,7 @@ u8 phydm_phystat_rpt_jgr3(void *dm_void, enum phystat_rpt info,
 	return return_info;
 }
 
-void phydm_ex_hal8814b_wifi_only_hw_config(void *dm_void)
+static void phydm_ex_hal8814b_wifi_only_hw_config(void *dm_void)
 {
 	/*BB control*/
 	/*halwifionly_phy_set_bb_reg(pwifionlycfg, 0x4c, 0x01800000, 0x2);*/
@@ -1748,7 +1748,7 @@ void phydm_user_position_for_sniffer(void *dm_void, u8 user_position)
 	odm_set_bb_reg(dm, R_0xa68, (BIT(19) | BIT(18)), user_position);
 }
 
-boolean
+static boolean
 phydm_bb_ctrl_txagc_ofst_jgr3(void *dm_void, s8 pw_offset, /*@(unit: dB)*/
 			      u8 add_half_db /*@(+0.5 dB)*/)
 {
@@ -2025,7 +2025,7 @@ void phydm_stop_ck320(void *dm_void, u8 enable)
 	}
 }
 
-boolean
+static boolean
 phydm_bb_ctrl_txagc_ofst(void *dm_void, s8 pw_offset, /*@(unit: dB)*/
 			 u8 add_half_db /*@(+0.5 dB)*/)
 {

--- a/hal/phydm/phydm_auto_dbg.c
+++ b/hal/phydm/phydm_auto_dbg.c
@@ -32,7 +32,7 @@
 
 #ifdef PHYDM_AUTO_DEGBUG
 
-void phydm_check_hang_reset(
+static void phydm_check_hang_reset(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -44,7 +44,7 @@ void phydm_check_hang_reset(
 	dm->debug_components &= (~ODM_COMP_API);
 }
 
-void phydm_check_hang_init(
+static void phydm_check_hang_init(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -351,7 +351,7 @@ void phydm_dbg_port_dump_n(void *dm_void, u32 *_used, char *output,
 #endif
 
 #if (ODM_IC_11AC_SERIES_SUPPORT == 1)
-void phydm_dbg_port_dump_ac(void *dm_void, u32 *_used, char *output,
+static void phydm_dbg_port_dump_ac(void *dm_void, u32 *_used, char *output,
 			    u32 *_out_len)
 {
 	u32 value32 = 0;
@@ -558,7 +558,7 @@ void phydm_dbg_port_dump_ac(void *dm_void, u32 *_used, char *output,
 #endif
 
 #ifdef PHYDM_IC_JGR3_SERIES_SUPPORT
-void phydm_dbg_port_dump_jgr3(void *dm_void, u32 *_used, char *output,
+static void phydm_dbg_port_dump_jgr3(void *dm_void, u32 *_used, char *output,
 			      u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;

--- a/hal/phydm/phydm_cck_pd.c
+++ b/hal/phydm/phydm_cck_pd.c
@@ -500,7 +500,7 @@ void phydm_cck_pd_init_type3(void *dm_void)
 #endif /*#ifdef PHYDM_COMPILE_CCKPD_TYPE3*/
 
 #ifdef PHYDM_COMPILE_CCKPD_TYPE4
-void phydm_write_cck_pd_type4(void *dm_void, enum cckpd_lv lv,
+static void phydm_write_cck_pd_type4(void *dm_void, enum cckpd_lv lv,
 			      enum cckpd_mode mode)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -579,7 +579,7 @@ void phydm_write_cck_pd_type4(void *dm_void, enum cckpd_lv lv,
 	}
 }
 
-void phydm_set_cck_pd_lv_type4(void *dm_void, enum cckpd_lv lv)
+static void phydm_set_cck_pd_lv_type4(void *dm_void, enum cckpd_lv lv)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_cckpd_struct *cckpd_t = &dm->dm_cckpd_table;
@@ -659,7 +659,7 @@ void phydm_set_cck_pd_lv_type4(void *dm_void, enum cckpd_lv lv)
 	phydm_write_cck_pd_type4(dm, lv, cck_mode);
 }
 
-void phydm_read_cckpd_para_type4(void *dm_void)
+static void phydm_read_cckpd_para_type4(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_cckpd_struct *cckpd_t = &dm->dm_cckpd_table;
@@ -715,7 +715,7 @@ void phydm_read_cckpd_para_type4(void *dm_void)
 		  curr_cck_pd_t[bw][n_rx - 1][0]);
 }
 
-void phydm_cckpd_type4(void *dm_void)
+static void phydm_cckpd_type4(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_cckpd_struct *cckpd_t = &dm->dm_cckpd_table;
@@ -798,7 +798,7 @@ void phydm_cckpd_type4(void *dm_void)
 	phydm_read_cckpd_para_type4(dm);
 }
 
-void phydm_cck_pd_init_type4(void *dm_void)
+static void phydm_cck_pd_init_type4(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_cckpd_struct *cckpd_t = &dm->dm_cckpd_table;
@@ -952,7 +952,7 @@ void phydm_cck_pd_init_type4(void *dm_void)
 	}
 }
 
-void phydm_invalid_cckpd_type4(void *dm_void)
+static void phydm_invalid_cckpd_type4(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_cckpd_struct *cckpd_t = &dm->dm_cckpd_table;
@@ -1026,7 +1026,7 @@ void phydm_set_cckpd_val(void *dm_void, u32 *val_buf, u8 val_len)
 	}
 }
 
-boolean
+static boolean
 phydm_stop_cck_pd_th(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;

--- a/hal/phydm/phydm_cck_rx_pathdiv.c
+++ b/hal/phydm/phydm_cck_rx_pathdiv.c
@@ -31,7 +31,7 @@
 #include "phydm_precomp.h"
 
 #ifdef PHYDM_CCK_RX_PATHDIV_SUPPORT /* @PHYDM-342*/
-void phydm_cck_rx_pathdiv_manaul(void *dm_void, boolean en_cck_rx_pathdiv)
+static void phydm_cck_rx_pathdiv_manaul(void *dm_void, boolean en_cck_rx_pathdiv)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 

--- a/hal/phydm/phydm_ccx.c
+++ b/hal/phydm/phydm_ccx.c
@@ -26,7 +26,7 @@
 #include "mp_precomp.h"
 #include "phydm_precomp.h"
 
-void phydm_ccx_hw_restart(void *dm_void)
+static void phydm_ccx_hw_restart(void *dm_void)
 			  /*@Will Restart NHM/CLM/FAHM simultaneously*/
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -328,7 +328,7 @@ void phydm_fahm_dbg(void *dm_void, char input[][16], u32 *_used, char *output,
 
 #ifdef NHM_SUPPORT
 
-void phydm_nhm_racing_release(void *dm_void)
+static void phydm_nhm_racing_release(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -348,7 +348,7 @@ void phydm_nhm_racing_release(void *dm_void)
 	ccx->nhm_app = NHM_BACKGROUND;
 }
 
-u8 phydm_nhm_racing_ctrl(void *dm_void, enum phydm_nhm_level nhm_lv)
+static u8 phydm_nhm_racing_ctrl(void *dm_void, enum phydm_nhm_level nhm_lv)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -373,7 +373,7 @@ u8 phydm_nhm_racing_ctrl(void *dm_void, enum phydm_nhm_level nhm_lv)
 	return set_result;
 }
 
-void phydm_nhm_trigger(void *dm_void)
+static void phydm_nhm_trigger(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -397,7 +397,7 @@ void phydm_nhm_trigger(void *dm_void)
 	ccx->nhm_ongoing = true;
 }
 
-boolean
+static boolean
 phydm_nhm_check_rdy(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -428,7 +428,7 @@ phydm_nhm_check_rdy(void *dm_void)
 	return is_ready;
 }
 
-u8 phydm_nhm_cal_noise(void *dm_void, u8 start_i, u8 end_i, u8 n_sum)
+static u8 phydm_nhm_cal_noise(void *dm_void, u8 start_i, u8 end_i, u8 n_sum)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -471,7 +471,7 @@ u8 phydm_nhm_cal_noise(void *dm_void, u8 start_i, u8 end_i, u8 n_sum)
 	return noise;
 }
 
-void phydm_nhm_get_utility(void *dm_void)
+static void phydm_nhm_get_utility(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -493,7 +493,7 @@ void phydm_nhm_get_utility(void *dm_void)
 	PHYDM_DBG(dm, DBG_ENV_MNTR, "nhm_ratio=%d\n", ccx->nhm_ratio);
 }
 
-boolean
+static boolean
 phydm_nhm_get_result(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -603,7 +603,7 @@ phydm_nhm_get_result(void *dm_void)
 	return true;
 }
 
-void phydm_nhm_set_th_reg(void *dm_void)
+static void phydm_nhm_set_th_reg(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -653,7 +653,7 @@ void phydm_nhm_set_th_reg(void *dm_void)
 		  ccx->nhm_th[1], ccx->nhm_th[0]);
 }
 
-boolean
+static boolean
 phydm_nhm_th_update_chk(void *dm_void, enum nhm_application nhm_app, u8 *nhm_th,
 			u32 *igi_new, boolean en_1db_mode, u8 nhm_th0_manual)
 {
@@ -768,7 +768,7 @@ phydm_nhm_th_update_chk(void *dm_void, enum nhm_application nhm_app, u8 *nhm_th,
 	return is_update;
 }
 
-void phydm_nhm_set(void *dm_void, enum nhm_option_txon_all include_tx,
+static void phydm_nhm_set(void *dm_void, enum nhm_option_txon_all include_tx,
 		   enum nhm_option_cca_all include_cca,
 		   enum nhm_divider_opt_all divi_opt,
 		   enum nhm_application nhm_app, u16 period,
@@ -853,7 +853,7 @@ void phydm_nhm_set(void *dm_void, enum nhm_option_txon_all include_tx,
 	}
 }
 
-u8 phydm_nhm_mntr_set(void *dm_void, struct nhm_para_info *nhm_para)
+static u8 phydm_nhm_mntr_set(void *dm_void, struct nhm_para_info *nhm_para)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u16 nhm_time = 0; /*unit: 4us*/
@@ -884,7 +884,7 @@ u8 phydm_nhm_mntr_set(void *dm_void, struct nhm_para_info *nhm_para)
 }
 
 #ifdef NHM_DYM_PW_TH_SUPPORT
-void
+static void
 phydm_nhm_restore_pw_th(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -893,7 +893,7 @@ phydm_nhm_restore_pw_th(void *dm_void)
 	odm_set_bb_reg(dm, R_0x82c, 0x3f, ccx->pw_th_rf20_ori);
 }
 
-void
+static void
 phydm_nhm_set_pw_th(void *dm_void, u8 noise, boolean chk_succ)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -950,7 +950,7 @@ phydm_nhm_set_pw_th(void *dm_void, u8 noise, boolean chk_succ)
 	}
 }
 
-void
+static void
 phydm_nhm_dym_pw_th(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -979,7 +979,7 @@ phydm_nhm_dym_pw_th(void *dm_void)
 	phydm_nhm_set_pw_th(dm, noise, chk_succ);
 }
 
-boolean
+static boolean
 phydm_nhm_dym_pw_th_en(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1004,7 +1004,7 @@ phydm_nhm_dym_pw_th_en(void *dm_void)
 #endif
 
 /*@Environment Monitor*/
-boolean
+static boolean
 phydm_nhm_mntr_chk(void *dm_void, u16 monitor_time /*unit ms*/)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1067,7 +1067,7 @@ phydm_nhm_mntr_chk(void *dm_void, u16 monitor_time /*unit ms*/)
 	return nhm_chk_result;
 }
 
-void phydm_nhm_init(void *dm_void)
+static void phydm_nhm_init(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -1262,7 +1262,7 @@ void phydm_nhm_dbg(void *dm_void, char input[][16], u32 *_used, char *output,
 
 #ifdef CLM_SUPPORT
 
-void phydm_clm_racing_release(void *dm_void)
+static void phydm_clm_racing_release(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -1275,7 +1275,7 @@ void phydm_clm_racing_release(void *dm_void)
 	ccx->clm_app = CLM_BACKGROUND;
 }
 
-u8 phydm_clm_racing_ctrl(void *dm_void, enum phydm_clm_level clm_lv)
+static u8 phydm_clm_racing_ctrl(void *dm_void, enum phydm_clm_level clm_lv)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -1317,7 +1317,7 @@ void phydm_clm_c2h_report_handler(void *dm_void, u8 *cmd_buf, u8 cmd_len)
 		  ccx_info->clm_fw_result_cnt, clm_report);
 }
 
-void phydm_clm_h2c(void *dm_void, u16 obs_time, u8 fw_clm_en)
+static void phydm_clm_h2c(void *dm_void, u16 obs_time, u8 fw_clm_en)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 h2c_val[H2C_MAX_LENGTH] = {0};
@@ -1353,7 +1353,7 @@ void phydm_clm_h2c(void *dm_void, u16 obs_time, u8 fw_clm_en)
 	odm_fill_h2c_cmd(dm, PHYDM_H2C_FW_CLM_MNTR, H2C_MAX_LENGTH, h2c_val);
 }
 
-void phydm_clm_setting(void *dm_void, u16 clm_period /*@4us sample 1 time*/)
+static void phydm_clm_setting(void *dm_void, u16 clm_period /*@4us sample 1 time*/)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -1378,7 +1378,7 @@ void phydm_clm_setting(void *dm_void, u16 clm_period /*@4us sample 1 time*/)
 		  ccx->clm_period);
 }
 
-void phydm_clm_trigger(void *dm_void)
+static void phydm_clm_trigger(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -1402,7 +1402,7 @@ void phydm_clm_trigger(void *dm_void)
 	ccx->clm_ongoing = true;
 }
 
-boolean
+static boolean
 phydm_clm_check_rdy(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1435,7 +1435,7 @@ phydm_clm_check_rdy(void *dm_void)
 	return is_ready;
 }
 
-void phydm_clm_get_utility(void *dm_void)
+static void phydm_clm_get_utility(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -1453,7 +1453,7 @@ void phydm_clm_get_utility(void *dm_void)
 	}
 }
 
-boolean
+static boolean
 phydm_clm_get_result(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1497,7 +1497,7 @@ phydm_clm_get_result(void *dm_void)
 	return true;
 }
 
-void phydm_clm_mntr_fw(void *dm_void, u16 monitor_time /*unit ms*/)
+static void phydm_clm_mntr_fw(void *dm_void, u16 monitor_time /*unit ms*/)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;
@@ -1527,7 +1527,7 @@ void phydm_clm_mntr_fw(void *dm_void, u16 monitor_time /*unit ms*/)
 	phydm_clm_h2c(dm, ccx->clm_period, true);
 }
 
-u8 phydm_clm_mntr_set(void *dm_void, struct clm_para_info *clm_para)
+static u8 phydm_clm_mntr_set(void *dm_void, struct clm_para_info *clm_para)
 {
 	/*@Driver Monitor CLM*/
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1557,7 +1557,7 @@ u8 phydm_clm_mntr_set(void *dm_void, struct clm_para_info *clm_para)
 	return PHYDM_SET_SUCCESS;
 }
 
-boolean
+static boolean
 phydm_clm_mntr_chk(void *dm_void, u16 monitor_time /*unit ms*/)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1606,7 +1606,7 @@ phydm_clm_mntr_chk(void *dm_void, u16 monitor_time /*unit ms*/)
 	return clm_chk_result;
 }
 
-void phydm_set_clm_mntr_mode(void *dm_void, enum clm_monitor_mode mode)
+static void phydm_set_clm_mntr_mode(void *dm_void, enum clm_monitor_mode mode)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx_info = &dm->dm_ccx_info;
@@ -1620,7 +1620,7 @@ void phydm_set_clm_mntr_mode(void *dm_void, enum clm_monitor_mode mode)
 	}
 }
 
-void phydm_clm_init(void *dm_void)
+static void phydm_clm_init(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ccx_info *ccx = &dm->dm_ccx_info;

--- a/hal/phydm/phydm_cfotracking.c
+++ b/hal/phydm/phydm_cfotracking.c
@@ -25,7 +25,7 @@
 #include "mp_precomp.h"
 #include "phydm_precomp.h"
 
-s32 phydm_get_cfo_hz(void *dm_void, u32 val, u8 bit_num, u8 frac_num)
+static s32 phydm_get_cfo_hz(void *dm_void, u32 val, u8 bit_num, u8 frac_num)
 {
 	s32 val_s = 0;
 
@@ -42,7 +42,7 @@ s32 phydm_get_cfo_hz(void *dm_void, u32 val, u8 bit_num, u8 frac_num)
 }
 
 #if (ODM_IC_11AC_SERIES_SUPPORT)
-void phydm_get_cfo_info_ac(void *dm_void, struct phydm_cfo_rpt *cfo)
+static void phydm_get_cfo_info_ac(void *dm_void, struct phydm_cfo_rpt *cfo)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 i = 0;
@@ -317,7 +317,7 @@ void phydm_set_crystal_cap(void *dm_void, u8 crystal_cap)
 		PHYDM_DBG(dm, DBG_CFO_TRK, "Set fail\n");
 }
 
-void phydm_cfo_tracking_reset(void *dm_void)
+static void phydm_cfo_tracking_reset(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_cfo_track_struct *cfo_track = &dm->dm_cfo_track;

--- a/hal/phydm/phydm_debug.c
+++ b/hal/phydm/phydm_debug.c
@@ -101,7 +101,7 @@ void phydm_bb_dbg_port_header_sel(void *dm_void, u32 header_idx)
 	}
 }
 
-void phydm_bb_dbg_port_clock_en(void *dm_void, u8 enable)
+static void phydm_bb_dbg_port_clock_en(void *dm_void, u8 enable)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 reg_value = 0;
@@ -414,7 +414,7 @@ void phydm_bb_hw_dbg_info_8822b(void *dm_void, u32 *_used, char *output,
 }
 #endif
 
-void phydm_bb_hw_dbg_info_ac(void *dm_void, u32 *_used, char *output,
+static void phydm_bb_hw_dbg_info_ac(void *dm_void, u32 *_used, char *output,
 			     u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -708,7 +708,7 @@ void phydm_bb_hw_dbg_info_ac(void *dm_void, u32 *_used, char *output,
 #endif
 
 #ifdef PHYDM_IC_JGR3_SERIES_SUPPORT
-void phydm_bb_hw_dbg_info_jgr3(void *dm_void, u32 *_used, char *output,
+static void phydm_bb_hw_dbg_info_jgr3(void *dm_void, u32 *_used, char *output,
 			       u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -940,7 +940,7 @@ u8 phydm_get_l_sig_rate(void *dm_void, u8 rate_idx_l_sig)
 	return rate_idx;
 }
 
-void phydm_bb_hw_dbg_info(void *dm_void, char input[][16], u32 *_used,
+static void phydm_bb_hw_dbg_info(void *dm_void, char input[][16], u32 *_used,
 			  char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1766,7 +1766,7 @@ void phydm_rx_rate_distribution(void *dm_void)
 #endif
 }
 
-u16 phydm_rx_utility(void *dm_void, u16 avg_phy_rate, u8 rx_max_ss,
+static u16 phydm_rx_utility(void *dm_void, u16 avg_phy_rate, u8 rx_max_ss,
 		     enum channel_width bw)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1863,7 +1863,7 @@ u16 phydm_rx_avg_phy_rate(void *dm_void)
 	return avg_phy_rate;
 }
 
-void phydm_print_hist_2_buf(void *dm_void, u16 *val, u16 len, char *buf,
+static void phydm_print_hist_2_buf(void *dm_void, u16 *val, u16 len, char *buf,
 			    u16 buf_size)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1883,7 +1883,7 @@ void phydm_print_hist_2_buf(void *dm_void, u16 *val, u16 len, char *buf,
 	}
 }
 
-void phydm_nss_hitogram(void *dm_void, enum PDM_RATE_TYPE rate_type)
+static void phydm_nss_hitogram(void *dm_void, enum PDM_RATE_TYPE rate_type)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_phy_dbg_info *dbg_i = &dm->phy_dbg_info;
@@ -2018,7 +2018,7 @@ void phydm_show_phy_hitogram(void *dm_void)
 	#endif
 }
 
-void phydm_avg_phy_val_nss(void *dm_void, u8 nss)
+static void phydm_avg_phy_val_nss(void *dm_void, u8 nss)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_phy_dbg_info *dbg_i = &dm->phy_dbg_info;
@@ -2291,7 +2291,7 @@ void phydm_get_phy_statistic(void *dm_void)
 	phydm_reset_phystatus_statistic(dm);
 };
 
-void phydm_basic_dbg_msg_linked(void *dm_void)
+static void phydm_basic_dbg_msg_linked(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_cfo_track_struct *cfo_t = &dm->dm_cfo_track;
@@ -3013,7 +3013,7 @@ void phydm_fw_trace_en_h2c(void *dm_void, boolean enable,
 	odm_fill_h2c_cmd(dm, PHYDM_H2C_FW_TRACE_EN, cmd_length, h2c_parameter);
 }
 
-void phydm_get_per_path_txagc(void *dm_void, u8 path, u32 *_used, char *output,
+static void phydm_get_per_path_txagc(void *dm_void, u8 path, u32 *_used, char *output,
 			      u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3087,7 +3087,7 @@ void phydm_get_per_path_txagc(void *dm_void, u8 path, u32 *_used, char *output,
 	*_out_len = out_len;
 }
 
-void phydm_get_txagc(void *dm_void, u32 *_used, char *output, u32 *_out_len)
+static void phydm_get_txagc(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 used = *_used;
@@ -3120,7 +3120,7 @@ void phydm_get_txagc(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 	*_out_len = out_len;
 }
 
-void phydm_set_txagc(void *dm_void, u32 *const val, u32 *_used,
+static void phydm_set_txagc(void *dm_void, u32 *const val, u32 *_used,
 		     char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3200,7 +3200,7 @@ void phydm_set_txagc(void *dm_void, u32 *const val, u32 *_used,
 	*_out_len = out_len;
 }
 
-void phydm_shift_txagc(void *dm_void, u32 *const val, u32 *_used, char *output,
+static void phydm_shift_txagc(void *dm_void, u32 *const val, u32 *_used, char *output,
 		       u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3314,7 +3314,7 @@ void phydm_shift_txagc(void *dm_void, u32 *const val, u32 *_used, char *output,
 	*_out_len = out_len;
 }
 
-void phydm_set_txagc_dbg(void *dm_void, char input[][16], u32 *_used,
+static void phydm_set_txagc_dbg(void *dm_void, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3395,7 +3395,7 @@ void phydm_set_txagc_dbg(void *dm_void, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-void phydm_cmn_msg_setting(void *dm_void, u32 *val, u32 *_used,
+static void phydm_cmn_msg_setting(void *dm_void, u32 *val, u32 *_used,
 			   char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3422,7 +3422,7 @@ void phydm_cmn_msg_setting(void *dm_void, u32 *val, u32 *_used,
 	*_out_len = out_len;
 }
 
-void phydm_debug_trace(void *dm_void, char input[][16], u32 *_used,
+static void phydm_debug_trace(void *dm_void, char input[][16], u32 *_used,
 		       char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3570,7 +3570,7 @@ void phydm_debug_trace(void *dm_void, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-void phydm_fw_debug_trace(void *dm_void, char input[][16], u32 *_used,
+static void phydm_fw_debug_trace(void *dm_void, char input[][16], u32 *_used,
 			  char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3647,7 +3647,7 @@ void phydm_dump_bb_reg_n(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 #endif
 
 #if (ODM_IC_11AC_SERIES_SUPPORT)
-void phydm_dump_bb_reg_ac(void *dm_void, u32 *_used, char *output,
+static void phydm_dump_bb_reg_ac(void *dm_void, u32 *_used, char *output,
 			  u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3705,7 +3705,7 @@ rpt_reg:
 #endif
 
 #ifdef PHYDM_IC_JGR3_SERIES_SUPPORT
-void phydm_dump_bb_reg_jgr3(void *dm_void, u32 *_used, char *output,
+static void phydm_dump_bb_reg_jgr3(void *dm_void, u32 *_used, char *output,
 			    u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3738,7 +3738,7 @@ void phydm_dump_bb_reg_jgr3(void *dm_void, u32 *_used, char *output,
 	*_out_len = out_len;
 }
 
-void phydm_dump_bb_reg2_jgr3(void *dm_void, u32 *_used, char *output,
+static void phydm_dump_bb_reg2_jgr3(void *dm_void, u32 *_used, char *output,
 			     u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3772,7 +3772,7 @@ void phydm_dump_bb_reg2_jgr3(void *dm_void, u32 *_used, char *output,
 	*_out_len = out_len;
 }
 
-void phydm_get_per_path_anapar_jgr3(void *dm_void, u8 path, u32 *_used,
+static void phydm_get_per_path_anapar_jgr3(void *dm_void, u8 path, u32 *_used,
 				    char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -3832,7 +3832,7 @@ void phydm_get_per_path_anapar_jgr3(void *dm_void, u8 path, u32 *_used,
 
 #endif
 
-void phydm_dump_bb_reg(void *dm_void, u32 *_used, char *output, u32 *_out_len)
+static void phydm_dump_bb_reg(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 used = *_used;
@@ -3870,7 +3870,7 @@ void phydm_dump_bb_reg(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 	*_out_len = out_len;
 }
 
-void phydm_dump_rf_reg(void *dm_void, u32 *_used, char *output, u32 *_out_len)
+static void phydm_dump_rf_reg(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 addr = 0;
@@ -3934,7 +3934,7 @@ void phydm_dump_rf_reg(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 	*_out_len = out_len;
 }
 
-void phydm_dump_mac_reg(void *dm_void, u32 *_used, char *output, u32 *_out_len)
+static void phydm_dump_mac_reg(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 addr = 0;
@@ -3959,7 +3959,7 @@ void phydm_dump_mac_reg(void *dm_void, u32 *_used, char *output, u32 *_out_len)
 	*_out_len = out_len;
 }
 
-void phydm_dump_reg(void *dm_void, char input[][16], u32 *_used, char *output,
+static void phydm_dump_reg(void *dm_void, char input[][16], u32 *_used, char *output,
 		    u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4006,7 +4006,7 @@ void phydm_dump_reg(void *dm_void, char input[][16], u32 *_used, char *output,
 	*_out_len = out_len;
 }
 
-void phydm_enable_big_jump(void *dm_void, char input[][16], u32 *_used,
+static void phydm_enable_big_jump(void *dm_void, char input[][16], u32 *_used,
 			   char *output, u32 *_out_len)
 {
 #if (RTL8822B_SUPPORT)
@@ -4043,7 +4043,7 @@ void phydm_enable_big_jump(void *dm_void, char input[][16], u32 *_used,
 #endif
 }
 
-void phydm_show_rx_rate(void *dm_void, char input[][16], u32 *_used,
+static void phydm_show_rx_rate(void *dm_void, char input[][16], u32 *_used,
 			char *output, u32 *_out_len)
 {
 #if (RTL8822B_SUPPORT || RTL8821C_SUPPORT || RTL8814B_SUPPORT ||\
@@ -4129,7 +4129,7 @@ void phydm_show_rx_rate(void *dm_void, char input[][16], u32 *_used,
 #endif
 }
 
-void phydm_per_tone_evm(void *dm_void, char input[][16], u32 *_used,
+static void phydm_per_tone_evm(void *dm_void, char input[][16], u32 *_used,
 			char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4341,7 +4341,7 @@ void phydm_per_tone_evm(void *dm_void, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-void phydm_bw_ch_adjust(void *dm_void, char input[][16],
+static void phydm_bw_ch_adjust(void *dm_void, char input[][16],
 			u32 *_used, char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4392,7 +4392,7 @@ out:
 	*_out_len = out_len;
 }
 
-void phydm_ext_rf_element_ctrl(void *dm_void, char input[][16], u32 *_used,
+static void phydm_ext_rf_element_ctrl(void *dm_void, char input[][16], u32 *_used,
 			       char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4412,7 +4412,7 @@ void phydm_ext_rf_element_ctrl(void *dm_void, char input[][16], u32 *_used,
 	}
 }
 
-void phydm_print_dbgport(void *dm_void, char input[][16], u32 *_used,
+static void phydm_print_dbgport(void *dm_void, char input[][16], u32 *_used,
 			 char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4460,7 +4460,7 @@ out:
 	*_out_len = out_len;
 }
 
-void phydm_get_anapar_table(void *dm_void, u32 *_used, char *output,
+static void phydm_get_anapar_table(void *dm_void, u32 *_used, char *output,
 			    u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4483,7 +4483,7 @@ void phydm_get_anapar_table(void *dm_void, u32 *_used, char *output,
 	*_out_len = out_len;
 }
 
-void phydm_dd_dbg_dump(void *dm_void, char input[][16], u32 *_used,
+static void phydm_dd_dbg_dump(void *dm_void, char input[][16], u32 *_used,
 		       char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4517,7 +4517,7 @@ void phydm_dd_dbg_dump(void *dm_void, char input[][16], u32 *_used,
 	}
 }
 
-void phydm_nss_hitogram_mp(void *dm_void, enum PDM_RATE_TYPE rate_type,
+static void phydm_nss_hitogram_mp(void *dm_void, enum PDM_RATE_TYPE rate_type,
 			   u32 *_used, char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4581,7 +4581,7 @@ void phydm_nss_hitogram_mp(void *dm_void, enum PDM_RATE_TYPE rate_type,
 	*_out_len = out_len;
 }
 
-void phydm_mp_dbg(void *dm_void, char input[][16], u32 *_used, char *output,
+static void phydm_mp_dbg(void *dm_void, char input[][16], u32 *_used, char *output,
 		  u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4812,7 +4812,7 @@ void phydm_mp_dbg(void *dm_void, char input[][16], u32 *_used, char *output,
 	*_out_len = out_len;
 }
 
-void phydm_reg_monitor(void *dm_void, char input[][16], u32 *_used,
+static void phydm_reg_monitor(void *dm_void, char input[][16], u32 *_used,
 		       char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4861,7 +4861,7 @@ void phydm_reg_monitor(void *dm_void, char input[][16], u32 *_used,
 }
 
 #if (RTL8822C_SUPPORT)
-u16 phydm_get_agc_rf_gain(void *dm_void, boolean is_mod, u8 tab, u8 mp_gain_i)
+static u16 phydm_get_agc_rf_gain(void *dm_void, boolean is_mod, u8 tab, u8 mp_gain_i)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u16 rf_gain = 0x0;
@@ -4875,7 +4875,7 @@ u16 phydm_get_agc_rf_gain(void *dm_void, boolean is_mod, u8 tab, u8 mp_gain_i)
 }
 #endif
 
-void phydm_get_rxagc_table_dbg(void *dm_void, char input[][16], u32 *_used,
+static void phydm_get_rxagc_table_dbg(void *dm_void, char input[][16], u32 *_used,
 			       char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -4934,7 +4934,7 @@ void phydm_get_rxagc_table_dbg(void *dm_void, char input[][16], u32 *_used,
 	*_out_len = out_len;
 }
 
-void phydm_shift_rxagc_table_dbg(void *dm_void, char input[][16], u32 *_used,
+static void phydm_shift_rxagc_table_dbg(void *dm_void, char input[][16], u32 *_used,
 				 char *output, u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;

--- a/hal/phydm/phydm_dfs.c
+++ b/hal/phydm/phydm_dfs.c
@@ -671,7 +671,7 @@ void phydm_dfs_parameter_init(void *dm_void)
 	dfs->type4_safe_pri_sum_th = 5;
 }
 
-void phydm_dfs_dynamic_setting(
+static void phydm_dfs_dynamic_setting(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -821,7 +821,7 @@ void phydm_dfs_dynamic_setting(
 	dfs->three_peak_th2 = three_peak_th2_cur;
 }
 
-boolean
+static boolean
 phydm_radar_detect_dm_check(
 	void *dm_void)
 {

--- a/hal/phydm/phydm_dig.c
+++ b/hal/phydm/phydm_dig.c
@@ -31,7 +31,7 @@
 #include "phydm_precomp.h"
 
 #ifdef CFG_DIG_DAMPING_CHK
-void phydm_dig_recorder_reset(void *dm_void)
+static void phydm_dig_recorder_reset(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;
@@ -43,7 +43,7 @@ void phydm_dig_recorder_reset(void *dm_void)
 		       sizeof(struct phydm_dig_recorder_strcut));
 }
 
-void phydm_dig_recorder(void *dm_void, u8 igi_curr,
+static void phydm_dig_recorder(void *dm_void, u8 igi_curr,
 			u32 fa_cnt)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -95,7 +95,7 @@ void phydm_dig_recorder(void *dm_void, u8 igi_curr,
 		  dig_rc->igi_bitmap);
 }
 
-void phydm_dig_damping_chk(void *dm_void)
+static void phydm_dig_damping_chk(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;
@@ -195,7 +195,7 @@ void phydm_dig_damping_chk(void *dm_void)
 }
 #endif
 
-void phydm_fa_threshold_check(void *dm_void, boolean is_dfs_band)
+static void phydm_fa_threshold_check(void *dm_void, boolean is_dfs_band)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;
@@ -234,7 +234,7 @@ void phydm_fa_threshold_check(void *dm_void, boolean is_dfs_band)
 		  dig_t->fa_th[1], dig_t->fa_th[2]);
 }
 
-void phydm_set_big_jump_step(void *dm_void, u8 curr_igi)
+static void phydm_set_big_jump_step(void *dm_void, u8 curr_igi)
 {
 #if (RTL8822B_SUPPORT || RTL8197F_SUPPORT || RTL8192F_SUPPORT)
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -266,7 +266,7 @@ void phydm_set_big_jump_step(void *dm_void, u8 curr_igi)
 }
 
 #ifdef PHYDM_IC_JGR3_SERIES_SUPPORT
-void phydm_write_dig_reg_jgr3(void *dm_void, u8 igi)
+static void phydm_write_dig_reg_jgr3(void *dm_void, u8 igi)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;
@@ -292,7 +292,7 @@ void phydm_write_dig_reg_jgr3(void *dm_void, u8 igi)
 	#endif
 }
 
-u8 phydm_get_igi_reg_val_jgr3(void *dm_void, enum bb_path path)
+static u8 phydm_get_igi_reg_val_jgr3(void *dm_void, enum bb_path path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 val = 0;
@@ -322,7 +322,7 @@ u8 phydm_get_igi_reg_val_jgr3(void *dm_void, enum bb_path path)
 	return (u8)val;
 }
 
-void phydm_fa_cnt_statistics_jgr3(void *dm_void)
+static void phydm_fa_cnt_statistics_jgr3(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_fa_struct *fa_t = &dm->false_alm_cnt;
@@ -427,7 +427,7 @@ void phydm_fa_cnt_statistics_jgr3(void *dm_void)
 
 #endif
 
-void phydm_write_dig_reg_c50(void *dm_void, u8 igi)
+static void phydm_write_dig_reg_c50(void *dm_void, u8 igi)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -546,7 +546,7 @@ void odm_write_dig(void *dm_void, u8 new_igi)
 	PHYDM_DBG(dm, DBG_DIG, "New_igi=((0x%x))\n\n", new_igi);
 }
 
-u8 phydm_get_igi_reg_val(void *dm_void, enum bb_path path)
+static u8 phydm_get_igi_reg_val(void *dm_void, enum bb_path path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 val = 0;
@@ -637,7 +637,7 @@ void odm_pause_dig(void *dm_void, enum phydm_pause_type type,
 	PHYDM_DBG(dm, DBG_DIG, "DIG pause_result=%d\n", rpt);
 }
 
-boolean
+static boolean
 phydm_dig_abort(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -736,7 +736,7 @@ void phydm_dig_init(void *dm_void)
 	dig_t->dig_dl_en = 1;
 #endif
 }
-void phydm_dig_abs_boundary_decision(struct dm_struct *dm, boolean is_dfs_band)
+static void phydm_dig_abs_boundary_decision(struct dm_struct *dm, boolean is_dfs_band)
 {
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;
 	struct phydm_adaptivity_struct *adapt = &dm->adaptivity;
@@ -788,7 +788,7 @@ void phydm_dig_abs_boundary_decision(struct dm_struct *dm, boolean is_dfs_band)
 		  dig_t->dm_dig_max, dig_t->dm_dig_min, dig_t->dig_max_of_min);
 }
 
-void phydm_dig_dym_boundary_decision(struct dm_struct *dm, boolean is_dfs_band)
+static void phydm_dig_dym_boundary_decision(struct dm_struct *dm, boolean is_dfs_band)
 {
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;
 #ifdef CFG_DIG_DAMPING_CHK
@@ -869,7 +869,7 @@ void phydm_dig_dym_boundary_decision(struct dm_struct *dm, boolean is_dfs_band)
 		  dig_t->rx_gain_range_max, dig_t->rx_gain_range_min);
 }
 
-void phydm_dig_abnormal_case(struct dm_struct *dm)
+static void phydm_dig_abnormal_case(struct dm_struct *dm)
 {
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;
 
@@ -881,7 +881,7 @@ void phydm_dig_abnormal_case(struct dm_struct *dm)
 		  dig_t->rx_gain_range_max, dig_t->rx_gain_range_min);
 }
 
-u8 phydm_new_igi_by_fa(struct dm_struct *dm, u8 igi, u32 fa_cnt, u8 *step_size)
+static u8 phydm_new_igi_by_fa(struct dm_struct *dm, u8 igi, u32 fa_cnt, u8 *step_size)
 {
 	boolean dig_go_up_check = true;
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;
@@ -896,7 +896,7 @@ u8 phydm_new_igi_by_fa(struct dm_struct *dm, u8 igi, u32 fa_cnt, u8 *step_size)
 	return igi;
 }
 
-u8 phydm_get_new_igi(struct dm_struct *dm, u8 igi, u32 fa_cnt,
+static u8 phydm_get_new_igi(struct dm_struct *dm, u8 igi, u32 fa_cnt,
 		     boolean is_dfs_band)
 {
 	struct phydm_dig_struct *dig_t = &dm->dm_dig_table;
@@ -988,7 +988,7 @@ u8 phydm_get_new_igi(struct dm_struct *dm, u8 igi, u32 fa_cnt,
 	return igi;
 }
 
-boolean phydm_dig_dfs_mode_en(void *dm_void)
+static boolean phydm_dig_dfs_mode_en(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	boolean dfs_mode_en = false;
@@ -1139,7 +1139,7 @@ void phydm_dig_by_rssi_lps(void *dm_void)
  * 3 FASLE ALARM CHECK
  * 3============================================================
  */
-void phydm_false_alarm_counter_reg_reset(void *dm_void)
+static void phydm_false_alarm_counter_reg_reset(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_fa_struct *falm_cnt = &dm->false_alm_cnt;
@@ -1235,7 +1235,7 @@ void phydm_false_alarm_counter_reg_reset(void *dm_void)
 #endif /* @#if (ODM_IC_11AC_SERIES_SUPPORT) */
 }
 
-void phydm_false_alarm_counter_reg_hold(void *dm_void)
+static void phydm_false_alarm_counter_reg_hold(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -1354,7 +1354,7 @@ void phydm_fa_cnt_statistics_n(void *dm_void)
 #endif
 
 #if (ODM_IC_11AC_SERIES_SUPPORT)
-void phydm_fa_cnt_statistics_ac(void *dm_void)
+static void phydm_fa_cnt_statistics_ac(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_fa_struct *fa_t = &dm->false_alm_cnt;
@@ -1461,7 +1461,7 @@ void phydm_fa_cnt_statistics_ac(void *dm_void)
 }
 #endif
 
-void phydm_get_dbg_port_info(void *dm_void)
+static void phydm_get_dbg_port_info(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_fa_struct *fa_t = &dm->false_alm_cnt;
@@ -1602,7 +1602,7 @@ void phydm_false_alarm_counter_statistics(void *dm_void)
 #endif
 }
 
-void phydm_fa_cnt_set_crc32_cnt2_rate(void *dm_void, u8 rate_idx)
+static void phydm_fa_cnt_set_crc32_cnt2_rate(void *dm_void, u8 rate_idx)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_fa_struct *fa_t = &dm->false_alm_cnt;

--- a/hal/phydm/phydm_dynamictxpower.c
+++ b/hal/phydm/phydm_dynamictxpower.c
@@ -76,7 +76,7 @@ void phydm_wt_reg_pwr(void *dm_void, boolean is_ofst1, boolean pwr_ofst_en,
 	}
 };
 
-void phydm_rd_ram_pwr(void *dm_void, u8 macid, u32 *_used, char *output,
+static void phydm_rd_ram_pwr(void *dm_void, u8 macid, u32 *_used, char *output,
 		      u32 *_out_len)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -148,7 +148,7 @@ void phydm_wt_ram_pwr(void *dm_void, u8 macid, boolean is_ofst1,
 	odm_set_bb_reg(dm, R_0x1e84, MASKDWORD, 0x0); /* disable rd/wt*/
 };
 
-void phydm_rst_ram_pwr(void *dm_void)
+static void phydm_rst_ram_pwr(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_bb_ram_per_sta *dm_ram_per_sta = NULL;
@@ -172,7 +172,7 @@ void phydm_rst_ram_pwr(void *dm_void)
 	odm_set_bb_reg(dm, R_0x1e84, MASKDWORD, 0x0);
 };
 
-u8 phydm_pwr_lv_mapping_2nd(u8 tx_pwr_lv)
+static u8 phydm_pwr_lv_mapping_2nd(u8 tx_pwr_lv)
 {
 	if (tx_pwr_lv == tx_high_pwr_level_level3)
 		return PHYDM_2ND_OFFSET_MINUS_11DB;
@@ -184,7 +184,7 @@ u8 phydm_pwr_lv_mapping_2nd(u8 tx_pwr_lv)
 		return PHYDM_2ND_OFFSET_ZERO;
 }
 
-void phydm_pwr_lv_ctrl(void *dm_void, u8 macid, u8 tx_pwr_lv)
+static void phydm_pwr_lv_ctrl(void *dm_void, u8 macid, u8 tx_pwr_lv)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	s8 pwr_offset = 0;
@@ -201,7 +201,7 @@ void phydm_pwr_lv_ctrl(void *dm_void, u8 macid, u8 tx_pwr_lv)
 	phydm_wt_ram_pwr(dm, macid, RAM_PWR_OFST0, true, pwr_offset);
 }
 
-void phydm_dtp_fill_cmninfo_2nd(void *dm_void, u8 sta_id, u8 dtp_lvl)
+static void phydm_dtp_fill_cmninfo_2nd(void *dm_void, u8 sta_id, u8 dtp_lvl)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct cmn_sta_info *sta = dm->phydm_sta_info[sta_id];
@@ -219,7 +219,7 @@ void phydm_dtp_fill_cmninfo_2nd(void *dm_void, u8 sta_id, u8 dtp_lvl)
 		  sta_id, sta->mac_id, dtp->dyn_tx_power);
 }
 
-void phydm_dtp_init_2nd(void *dm_void)
+static void phydm_dtp_init_2nd(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -236,7 +236,7 @@ void phydm_dtp_init_2nd(void *dm_void)
 };
 #endif
 
-boolean
+static boolean
 phydm_check_rates(void *dm_void, u8 rate_idx)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -300,7 +300,7 @@ phydm_check_rates(void *dm_void, u8 rate_idx)
 		return false;
 }
 
-enum rf_path
+static enum rf_path
 phydm_check_paths(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -331,7 +331,7 @@ u8 phydm_dtp_get_txagc(void *dm_void, enum rf_path path, u8 hw_rate)
 }
 #endif
 
-u8 phydm_search_min_power_index(void *dm_void)
+static u8 phydm_search_min_power_index(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	enum rf_path path;
@@ -399,7 +399,7 @@ void phydm_dynamic_tx_power_init(void *dm_void)
 	}
 }
 
-void phydm_noisy_enhance_hp_th(void *dm_void, u8 noisy_state)
+static void phydm_noisy_enhance_hp_th(void *dm_void, u8 noisy_state)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -418,7 +418,7 @@ void phydm_noisy_enhance_hp_th(void *dm_void, u8 noisy_state)
 		  dm->enhance_pwr_th[2]);
 }
 
-u8 phydm_pwr_lvl_check(void *dm_void, u8 input_rssi)
+static u8 phydm_pwr_lvl_check(void *dm_void, u8 input_rssi)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 th0, th1, th2;
@@ -448,7 +448,7 @@ u8 phydm_pwr_lvl_check(void *dm_void, u8 input_rssi)
 		return tx_high_pwr_level_unchange;
 }
 
-u8 phydm_pwr_lv_mapping(u8 tx_pwr_lv)
+static u8 phydm_pwr_lv_mapping(u8 tx_pwr_lv)
 {
 	if (tx_pwr_lv == tx_high_pwr_level_level3)
 		return PHYDM_OFFSET_MINUS_11DB;
@@ -460,7 +460,7 @@ u8 phydm_pwr_lv_mapping(u8 tx_pwr_lv)
 		return PHYDM_OFFSET_ZERO;
 }
 
-void phydm_dynamic_response_power(void *dm_void)
+static void phydm_dynamic_response_power(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 rpwr = 0;
@@ -484,7 +484,7 @@ void phydm_dynamic_response_power(void *dm_void)
 		  dm->dynamic_tx_high_power_lvl);
 }
 
-void phydm_dtp_fill_cmninfo(void *dm_void, u8 sta_id, u8 dtp_lvl)
+static void phydm_dtp_fill_cmninfo(void *dm_void, u8 sta_id, u8 dtp_lvl)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct cmn_sta_info *sta = dm->phydm_sta_info[sta_id];
@@ -500,7 +500,7 @@ void phydm_dtp_fill_cmninfo(void *dm_void, u8 sta_id, u8 dtp_lvl)
 		  sta_id, sta->mac_id, dtp->dyn_tx_power);
 }
 
-void phydm_dtp_per_sta(void *dm_void)
+static void phydm_dtp_per_sta(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct cmn_sta_info *sta = NULL;

--- a/hal/phydm/phydm_interface.c
+++ b/hal/phydm/phydm_interface.c
@@ -767,7 +767,7 @@ void odm_release_timer(struct dm_struct *dm, struct phydm_timer_list *timer)
 #endif
 }
 
-u8 phydm_trans_h2c_id(struct dm_struct *dm, u8 phydm_h2c_id)
+static u8 phydm_trans_h2c_id(struct dm_struct *dm, u8 phydm_h2c_id)
 {
 	u8 platform_h2c_id = phydm_h2c_id;
 

--- a/hal/phydm/phydm_mp.c
+++ b/hal/phydm/phydm_mp.c
@@ -33,7 +33,7 @@
 #ifdef PHYDM_MP_SUPPORT
 #ifdef PHYDM_IC_JGR3_SERIES_SUPPORT
 
-void phydm_mp_set_single_tone_jgr3(void *dm_void, boolean is_single_tone,
+static void phydm_mp_set_single_tone_jgr3(void *dm_void, boolean is_single_tone,
 				   u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -155,7 +155,7 @@ void phydm_mp_set_single_tone_jgr3(void *dm_void, boolean is_single_tone,
 	}
 }
 
-void phydm_mp_set_carrier_supp_jgr3(void *dm_void, boolean is_carrier_supp,
+static void phydm_mp_set_carrier_supp_jgr3(void *dm_void, boolean is_carrier_supp,
 				    u32 rate_index)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;

--- a/hal/phydm/phydm_noisemonitor.c
+++ b/hal/phydm/phydm_noisemonitor.c
@@ -39,7 +39,7 @@
  *
  *************************************************/
 
-void phydm_set_noise_data_sum(struct noise_level *noise_data, u8 max_rf_path)
+static void phydm_set_noise_data_sum(struct noise_level *noise_data, u8 max_rf_path)
 {
 	u8 i = 0;
 
@@ -152,7 +152,7 @@ s16 odm_inband_noise_monitor_n(struct dm_struct *dm, u8 is_pause_dig, u8 igi,
 #endif
 
 #if (ODM_IC_11AC_SERIES_SUPPORT)
-s16 phydm_idle_noise_measure_ac(struct dm_struct *dm, u8 pause_dig,
+static s16 phydm_idle_noise_measure_ac(struct dm_struct *dm, u8 pause_dig,
 				u8 igi, u32 max_time)
 {
 	u32 tmp4b;
@@ -251,7 +251,7 @@ s16 phydm_idle_noise_measure_ac(struct dm_struct *dm, u8 pause_dig,
 	return dm->noise_level.noise_all;
 }
 
-s16 odm_inband_noise_monitor_ac(struct dm_struct *dm, u8 pause_dig, u8 igi,
+static s16 odm_inband_noise_monitor_ac(struct dm_struct *dm, u8 pause_dig, u8 igi,
 				u32 max_time)
 {
 	s32 rxi_buf_anta, rxq_buf_anta; /*rxi_buf_antb, rxq_buf_antb;*/

--- a/hal/phydm/phydm_pathdiv.c
+++ b/hal/phydm/phydm_pathdiv.c
@@ -597,7 +597,7 @@ void phydm_path_diversity_init_8812a(void *dm_void)
 #endif
 
 #ifdef PHYDM_IC_JGR3_SERIES_SUPPORT
-void phydm_set_resp_tx_path_by_fw_jgr3(void *dm_void, u8 macid,
+static void phydm_set_resp_tx_path_by_fw_jgr3(void *dm_void, u8 macid,
 				       enum bb_path path, boolean enable)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -668,7 +668,7 @@ void phydm_get_tx_path_txdesc_jgr3(void *dm_void, u8 macid,
 }
 #endif
 
-void phydm_tx_path_by_mac_or_reg(void *dm_void, enum phydm_path_ctrl ctrl)
+static void phydm_tx_path_by_mac_or_reg(void *dm_void, enum phydm_path_ctrl ctrl)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct _ODM_PATH_DIVERSITY_ *p_div = &dm->dm_path_div;
@@ -714,7 +714,7 @@ void phydm_tx_path_by_mac_or_reg(void *dm_void, enum phydm_path_ctrl ctrl)
 	}
 }
 
-void phydm_fix_1ss_tx_path_by_bb_reg(void *dm_void,
+static void phydm_fix_1ss_tx_path_by_bb_reg(void *dm_void,
 				     enum bb_path tx_path_sel_1ss,
 				     enum bb_path tx_path_sel_cck)
 {
@@ -816,7 +816,7 @@ void phydm_set_tx_path_by_bb_reg(void *dm_void, enum bb_path tx_path_sel_1ss)
 	}
 }
 
-void phydm_tx_path_diversity_2ss(void *dm_void)
+static void phydm_tx_path_diversity_2ss(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct _ODM_PATH_DIVERSITY_ *p_div = &dm->dm_path_div;
@@ -947,7 +947,7 @@ void phydm_tx_path_diversity(void *dm_void)
 	}
 }
 
-void phydm_tx_path_diversity_init_v2(void *dm_void)
+static void phydm_tx_path_diversity_init_v2(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct _ODM_PATH_DIVERSITY_ *p_div = &dm->dm_path_div;

--- a/hal/phydm/phydm_phystatus.c
+++ b/hal/phydm/phydm_phystatus.c
@@ -31,7 +31,7 @@
 #include "phydm_precomp.h"
 
 #ifdef PHYDM_COMPILE_MU
-u8 phydm_get_gid(struct dm_struct *dm, u8 *phy_status_inf)
+static u8 phydm_get_gid(struct dm_struct *dm, u8 *phy_status_inf)
 {
 #if (ODM_PHY_STATUS_NEW_TYPE_SUPPORT)
 	struct phy_sts_rpt_jgr2_type1 *rpt_jgr2 = NULL;
@@ -68,7 +68,7 @@ u8 phydm_get_gid(struct dm_struct *dm, u8 *phy_status_inf)
 }
 #endif
 
-void phydm_rx_statistic_cal(struct dm_struct *dm,
+static void phydm_rx_statistic_cal(struct dm_struct *dm,
 			    struct phydm_phyinfo_struct *phy_info,
 			    u8 *phy_status_inf,
 			    struct phydm_perpkt_info_struct *pktinfo)
@@ -197,7 +197,7 @@ void phydm_reset_phystatus_statistic(struct dm_struct *dm)
 		       sizeof(struct phydm_phystatus_statistic));
 }
 
-void phydm_reset_phy_info(struct dm_struct *dm,
+static void phydm_reset_phy_info(struct dm_struct *dm,
 			  struct phydm_phyinfo_struct *phy_info)
 {
 	u8 i = 0;
@@ -212,7 +212,7 @@ void phydm_reset_phy_info(struct dm_struct *dm,
 		phy_info->rx_pwr[i] = -110;
 }
 
-void phydm_avg_rssi_evm_snr(void *dm_void,
+static void phydm_avg_rssi_evm_snr(void *dm_void,
 			    struct phydm_phyinfo_struct *phy_info,
 			    struct phydm_perpkt_info_struct *pktinfo)
 {
@@ -365,7 +365,7 @@ void phydm_avg_rssi_evm_snr(void *dm_void,
 	}
 }
 
-void phydm_avg_phystatus_init(void *dm_void)
+static void phydm_avg_phystatus_init(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_phy_dbg_info *dbg_i = &dm->phy_dbg_info;
@@ -389,7 +389,7 @@ void phydm_avg_phystatus_init(void *dm_void)
 	#endif
 }
 
-u8 phydm_get_signal_quality(struct phydm_phyinfo_struct *phy_info,
+static u8 phydm_get_signal_quality(struct phydm_phyinfo_struct *phy_info,
 			    struct dm_struct *dm,
 			    struct phy_status_rpt_8192cd *phy_sts)
 {
@@ -412,7 +412,7 @@ u8 phydm_get_signal_quality(struct phydm_phyinfo_struct *phy_info,
 	return result;
 }
 
-u8 phydm_pw_2_percent(s8 ant_power)
+static u8 phydm_pw_2_percent(s8 ant_power)
 {
 	if ((ant_power <= -100) || ant_power >= 20)
 		return 0;
@@ -653,7 +653,7 @@ phydm_evm_2_percent(s8 value)
 	return (u8)ret_val;
 }
 
-s8 phydm_cck_rssi_convert(struct dm_struct *dm, u16 lna_idx, u8 vga_idx)
+static s8 phydm_cck_rssi_convert(struct dm_struct *dm, u16 lna_idx, u8 vga_idx)
 {
 	/*@phydm_get_cck_rssi_table_from_reg*/
 	return (dm->cck_lna_gain_table[lna_idx] - (vga_idx << 1));
@@ -694,7 +694,7 @@ void phydm_get_cck_rssi_table_from_reg(struct dm_struct *dm)
 		  dm->cck_lna_gain_table[6], dm->cck_lna_gain_table[7]);
 }
 
-s8 phydm_get_cck_rssi(void *dm_void, u8 lna_idx, u8 vga_idx)
+static s8 phydm_get_cck_rssi(void *dm_void, u8 lna_idx, u8 vga_idx)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	s8 rx_pow = 0;
@@ -1010,7 +1010,7 @@ phydm_evm_dbm(s8 value)
 	return (u8)ret_val;
 }
 
-void phydm_rx_physts_bw_parsing(struct phydm_phyinfo_struct *phy_info,
+static void phydm_rx_physts_bw_parsing(struct phydm_phyinfo_struct *phy_info,
 				struct phydm_perpkt_info_struct *
 				pktinfo,
 				struct phy_status_rpt_8812 *
@@ -1043,7 +1043,7 @@ void phydm_rx_physts_bw_parsing(struct phydm_phyinfo_struct *phy_info,
 	}
 }
 
-void phydm_get_sq(struct dm_struct *dm, struct phydm_phyinfo_struct *phy_info,
+static void phydm_get_sq(struct dm_struct *dm, struct phydm_phyinfo_struct *phy_info,
 		  u8 is_cck_rate)
 {
 	u8 sq = 0;
@@ -1083,7 +1083,7 @@ void phydm_get_sq(struct dm_struct *dm, struct phydm_phyinfo_struct *phy_info,
 	phy_info->signal_quality = sq;
 }
 
-void phydm_rx_physts_1st_type(struct dm_struct *dm,
+static void phydm_rx_physts_1st_type(struct dm_struct *dm,
 			      struct phydm_phyinfo_struct *phy_info,
 			      u8 *phy_status_inf,
 			      struct phydm_perpkt_info_struct *pktinfo)
@@ -1244,7 +1244,7 @@ void phydm_reset_rssi_for_dm(struct dm_struct *dm, u8 station_id)
 
 #if (ODM_IC_11N_SERIES_SUPPORT || ODM_IC_11AC_SERIES_SUPPORT)
 
-s32 phydm_get_rssi_8814_ofdm(struct dm_struct *dm, u8 *rssi_in)
+static s32 phydm_get_rssi_8814_ofdm(struct dm_struct *dm, u8 *rssi_in)
 {
 	s32 rssi_avg;
 	u8 rx_count = 0;
@@ -1290,7 +1290,7 @@ s32 phydm_get_rssi_8814_ofdm(struct dm_struct *dm, u8 *rssi_in)
 	return rssi_avg;
 }
 
-void phydm_process_rssi_for_dm(struct dm_struct *dm,
+static void phydm_process_rssi_for_dm(struct dm_struct *dm,
 			       struct phydm_phyinfo_struct *phy_info,
 			       struct phydm_perpkt_info_struct *pktinfo)
 {
@@ -1661,7 +1661,7 @@ void phydm_avg_condi_num(void *dm_void,
 }
 #endif
 
-void phydm_print_phystat_jgr3(struct dm_struct *dm, u8 *phy_sts,
+static void phydm_print_phystat_jgr3(struct dm_struct *dm, u8 *phy_sts,
 			      struct phydm_perpkt_info_struct *pktinfo,
 			      struct phydm_phyinfo_struct *phy_info)
 {
@@ -1852,7 +1852,7 @@ void phydm_print_phystat_jgr3(struct dm_struct *dm, u8 *phy_sts,
 	}
 }
 
-void phydm_reset_phy_info_jgr3(struct dm_struct *phydm,
+static void phydm_reset_phy_info_jgr3(struct dm_struct *phydm,
 			       struct phydm_phyinfo_struct *phy_info)
 {
 	u8 i;
@@ -1921,7 +1921,7 @@ void phydm_common_phy_info_jgr3(s8 rx_power, u8 channel, boolean is_beamformed,
 }
 #endif
 
-void phydm_get_physts_0_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
+static void phydm_get_physts_0_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 			     struct phydm_perpkt_info_struct *pktinfo,
 			     struct phydm_phyinfo_struct *phy_info)
 {
@@ -2038,7 +2038,7 @@ void phydm_get_physts_0_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 	#endif
 }
 
-void phydm_get_physts_1_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
+static void phydm_get_physts_1_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 				    struct phydm_perpkt_info_struct *pktinfo,
 				    struct phydm_phyinfo_struct *phy_info)
 {
@@ -2086,7 +2086,7 @@ void phydm_get_physts_1_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 #endif
 }
 
-void phydm_get_physts_2_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
+static void phydm_get_physts_2_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 				    struct phydm_perpkt_info_struct *pktinfo,
 				    struct phydm_phyinfo_struct *phy_info)
 {
@@ -2094,7 +2094,7 @@ void phydm_get_physts_2_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 	struct phy_sts_rpt_jgr3_type2_3 *phy_sts = NULL;
 }
 
-void phydm_get_physts_4_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
+static void phydm_get_physts_4_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 				    struct phydm_perpkt_info_struct *pktinfo,
 				    struct phydm_phyinfo_struct *phy_info)
 {
@@ -2131,7 +2131,7 @@ void phydm_get_physts_4_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 	dbg_i->condition_num_seg0 = phy_sts->avg_cond_num_0;
 }
 
-void phydm_get_physts_5_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
+static void phydm_get_physts_5_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 				    struct phydm_perpkt_info_struct *pktinfo,
 				    struct phydm_phyinfo_struct *phy_info)
 {
@@ -2139,7 +2139,7 @@ void phydm_get_physts_5_others_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 
 }
 
-void phydm_get_physts_ofdm_cmn_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
+static void phydm_get_physts_ofdm_cmn_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 				    struct phydm_perpkt_info_struct *pktinfo,
 				    struct phydm_phyinfo_struct *phy_info)
 {
@@ -2186,7 +2186,7 @@ void phydm_get_physts_ofdm_cmn_jgr3(struct dm_struct *dm, u8 *phy_status_inf,
 	dbg_i->num_qry_bf_pkt += phy_sts->beamformed;
 }
 
-void phydm_process_dm_rssi_jgr3(struct dm_struct *dm,
+static void phydm_process_dm_rssi_jgr3(struct dm_struct *dm,
 				struct phydm_phyinfo_struct *phy_info,
 				struct phydm_perpkt_info_struct *pktinfo)
 {
@@ -2281,7 +2281,7 @@ void phydm_process_dm_rssi_jgr3(struct dm_struct *dm,
 		rssi_t->rssi_ofdm = (s8)rssi_db;
 }
 
-void phydm_rx_physts_jgr3(void *dm_void, u8 *phy_sts,
+static void phydm_rx_physts_jgr3(void *dm_void, u8 *phy_sts,
 			  struct phydm_perpkt_info_struct *pktinfo,
 			  struct phydm_phyinfo_struct *phy_info)
 {

--- a/hal/phydm/phydm_pmac_tx_setting.c
+++ b/hal/phydm/phydm_pmac_tx_setting.c
@@ -33,7 +33,7 @@
 #ifdef PHYDM_PMAC_TX_SETTING_SUPPORT
 #ifdef PHYDM_IC_JGR3_SERIES_SUPPORT
 
-void phydm_start_cck_cont_tx_jgr3(void *dm_void,
+static void phydm_start_cck_cont_tx_jgr3(void *dm_void,
 				  struct phydm_pmac_info *tx_info)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -62,7 +62,7 @@ void phydm_start_cck_cont_tx_jgr3(void *dm_void,
 	pmac_tx->ofdm_cont_tx = false;
 }
 
-void phydm_stop_cck_cont_tx_jgr3(void *dm_void)
+static void phydm_stop_cck_cont_tx_jgr3(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_pmac_tx *pmac_tx = &dm->dm_pmac_tx_table;
@@ -82,7 +82,7 @@ void phydm_stop_cck_cont_tx_jgr3(void *dm_void)
 	odm_set_bb_reg(dm, R_0x1d0c, BIT(16), 0x1);
 }
 
-void phydm_start_ofdm_cont_tx_jgr3(void *dm_void)
+static void phydm_start_ofdm_cont_tx_jgr3(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_pmac_tx *pmac_tx = &dm->dm_pmac_tx_table;
@@ -104,7 +104,7 @@ void phydm_start_ofdm_cont_tx_jgr3(void *dm_void)
 	pmac_tx->ofdm_cont_tx = true;
 }
 
-void phydm_stop_ofdm_cont_tx_jgr3(void *dm_void)
+static void phydm_stop_ofdm_cont_tx_jgr3(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_pmac_tx *pmac_tx = &dm->dm_pmac_tx_table;
@@ -123,7 +123,7 @@ void phydm_stop_ofdm_cont_tx_jgr3(void *dm_void)
 	odm_set_bb_reg(dm, R_0x1d0c, BIT(16), 0x1);
 }
 
-void phydm_set_single_tone_jgr3(void *dm_void, boolean is_single_tone,
+static void phydm_set_single_tone_jgr3(void *dm_void, boolean is_single_tone,
 				boolean en_pmac_tx, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -234,7 +234,7 @@ void phydm_set_single_tone_jgr3(void *dm_void, boolean is_single_tone,
 	}
 }
 
-void phydm_stop_pmac_tx_jgr3(void *dm_void, struct phydm_pmac_info *tx_info)
+static void phydm_stop_pmac_tx_jgr3(void *dm_void, struct phydm_pmac_info *tx_info)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_pmac_tx *pmac_tx = &dm->dm_pmac_tx_table;
@@ -265,7 +265,7 @@ void phydm_stop_pmac_tx_jgr3(void *dm_void, struct phydm_pmac_info *tx_info)
 	}
 }
 
-void phydm_set_mac_phy_txinfo_jgr3(void *dm_void,
+static void phydm_set_mac_phy_txinfo_jgr3(void *dm_void,
 				   struct phydm_pmac_info *tx_info)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -309,7 +309,7 @@ void phydm_set_mac_phy_txinfo_jgr3(void *dm_void,
 	odm_set_bb_reg(dm, R_0x9b8, 0xffff0000, tmp);
 }
 
-void phydm_set_sig_jgr3(void *dm_void, struct phydm_pmac_info *tx_info)
+static void phydm_set_sig_jgr3(void *dm_void, struct phydm_pmac_info *tx_info)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_pmac_tx *pmac_tx = &dm->dm_pmac_tx_table;
@@ -370,7 +370,7 @@ void phydm_set_sig_jgr3(void *dm_void, struct phydm_pmac_info *tx_info)
 	}
 }
 
-void phydm_set_cck_preamble_hdr_jgr3(void *dm_void,
+static void phydm_set_cck_preamble_hdr_jgr3(void *dm_void,
 				     struct phydm_pmac_info *tx_info)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -394,7 +394,7 @@ void phydm_set_cck_preamble_hdr_jgr3(void *dm_void,
 		odm_set_bb_reg(dm, R_0x1e6c, BIT(16), 1);
 }
 
-void phydm_set_mode_jgr3(void *dm_void, struct phydm_pmac_info *tx_info,
+static void phydm_set_mode_jgr3(void *dm_void, struct phydm_pmac_info *tx_info,
 			 enum phydm_pmac_mode mode)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -418,7 +418,7 @@ void phydm_set_mode_jgr3(void *dm_void, struct phydm_pmac_info *tx_info,
 	}
 }
 
-void phydm_set_pmac_txon_jgr3(void *dm_void, struct phydm_pmac_info *tx_info)
+static void phydm_set_pmac_txon_jgr3(void *dm_void, struct phydm_pmac_info *tx_info)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_pmac_tx *pmac_tx = &dm->dm_pmac_tx_table;
@@ -443,7 +443,7 @@ void phydm_set_pmac_txon_jgr3(void *dm_void, struct phydm_pmac_info *tx_info)
 		phydm_set_single_tone_jgr3(dm, true, true, pmac_tx->path);
 }
 
-void phydm_set_pmac_tx_jgr3(void *dm_void, struct phydm_pmac_info *tx_info,
+static void phydm_set_pmac_tx_jgr3(void *dm_void, struct phydm_pmac_info *tx_info,
 			    enum rf_path mpt_rf_path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -471,7 +471,7 @@ void phydm_set_pmac_tx_jgr3(void *dm_void, struct phydm_pmac_info *tx_info,
 	phydm_set_pmac_txon_jgr3(dm, tx_info);
 }
 
-void phydm_set_tmac_tx_jgr3(void *dm_void)
+static void phydm_set_tmac_tx_jgr3(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 

--- a/hal/phydm/phydm_rainfo.c
+++ b/hal/phydm/phydm_rainfo.c
@@ -356,7 +356,7 @@ void odm_c2h_ra_para_report_handler(void *dm_void, u8 *cmd_buf, u8 cmd_len)
 	PHYDM_DBG(dm, DBG_FW_TRACE, "-------------------------------\n");
 }
 
-void phydm_ra_dynamic_retry_count(void *dm_void)
+static void phydm_ra_dynamic_retry_count(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 
@@ -668,7 +668,7 @@ void phydm_update_hal_ra_mask(
 
 #endif
 
-void phydm_rate_adaptive_mask_init(void *dm_void)
+static void phydm_rate_adaptive_mask_init(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ra_table *ra_t = &dm->dm_ra_table;
@@ -838,7 +838,7 @@ u8 phydm_get_rx_stream_num(void *dm_void, enum rf_type type)
 	return rx_num;
 }
 
-u8 phydm_get_tx_stream_num(void *dm_void, enum rf_type type)
+static u8 phydm_get_tx_stream_num(void *dm_void, enum rf_type type)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u8 tx_num = 1;
@@ -857,7 +857,7 @@ u8 phydm_get_tx_stream_num(void *dm_void, enum rf_type type)
 	return tx_num;
 }
 
-u64 phydm_get_bb_mod_ra_mask(void *dm_void, u8 sta_idx)
+static u64 phydm_get_bb_mod_ra_mask(void *dm_void, u8 sta_idx)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct cmn_sta_info *sta = dm->phydm_sta_info[sta_idx];
@@ -1034,7 +1034,7 @@ u8 phydm_get_rate_from_rssi_lv(void *dm_void, u8 sta_idx)
 	return rate_idx;
 }
 
-u8 phydm_get_rate_id(void *dm_void, u8 sta_idx)
+static u8 phydm_get_rate_id(void *dm_void, u8 sta_idx)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct cmn_sta_info *sta = dm->phydm_sta_info[sta_idx];
@@ -1149,7 +1149,7 @@ u8 phydm_get_rate_id(void *dm_void, u8 sta_idx)
 	return rate_id_idx;
 }
 
-void phydm_ra_h2c(void *dm_void, u8 sta_idx, u8 dis_ra, u8 dis_pt,
+static void phydm_ra_h2c(void *dm_void, u8 sta_idx, u8 dis_ra, u8 dis_pt,
 		  u8 no_update_bw, u8 init_ra_lv, u64 ra_mask)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1424,7 +1424,7 @@ u8 phydm_vht_en_mapping(void *dm_void, u32 wireless_mode)
 	return vht_en_out;
 }
 
-u8 phydm_rftype2rateid_2g_n20(void *dm_void, u8 rf_type)
+static u8 phydm_rftype2rateid_2g_n20(void *dm_void, u8 rf_type)
 {
 	u8 rate_id_idx = 0;
 
@@ -1439,7 +1439,7 @@ u8 phydm_rftype2rateid_2g_n20(void *dm_void, u8 rf_type)
 	return rate_id_idx;
 }
 
-u8 phydm_rftype2rateid_2g_n40(void *dm_void, u8 rf_type)
+static u8 phydm_rftype2rateid_2g_n40(void *dm_void, u8 rf_type)
 {
 	u8 rate_id_idx = 0;
 
@@ -1454,7 +1454,7 @@ u8 phydm_rftype2rateid_2g_n40(void *dm_void, u8 rf_type)
 	return rate_id_idx;
 }
 
-u8 phydm_rftype2rateid_5g_n(void *dm_void, u8 rf_type)
+static u8 phydm_rftype2rateid_5g_n(void *dm_void, u8 rf_type)
 {
 	u8 rate_id_idx = 0;
 
@@ -1469,7 +1469,7 @@ u8 phydm_rftype2rateid_5g_n(void *dm_void, u8 rf_type)
 	return rate_id_idx;
 }
 
-u8 phydm_rftype2rateid_ac80(void *dm_void, u8 rf_type)
+static u8 phydm_rftype2rateid_ac80(void *dm_void, u8 rf_type)
 {
 	u8 rate_id_idx = 0;
 
@@ -1484,7 +1484,7 @@ u8 phydm_rftype2rateid_ac80(void *dm_void, u8 rf_type)
 	return rate_id_idx;
 }
 
-u8 phydm_rftype2rateid_ac40(void *dm_void, u8 rf_type)
+static u8 phydm_rftype2rateid_ac40(void *dm_void, u8 rf_type)
 {
 	u8 rate_id_idx = 0;
 
@@ -1587,7 +1587,7 @@ u8 phydm_rssi_lv_dec(void *dm_void, u32 rssi, u8 ratr_state)
 	return new_rssi_lv;
 }
 
-enum phydm_qam_order phydm_get_ofdm_qam_order(void *dm_void, u8 rate_idx)
+static enum phydm_qam_order phydm_get_ofdm_qam_order(void *dm_void, u8 rate_idx)
 {
 	u8 tmp_idx = rate_idx;
 	enum phydm_qam_order qam_order = PHYDM_QAM_BPSK;
@@ -1668,7 +1668,7 @@ u8 phydm_rate_order_compute(void *dm_void, u8 rate_idx)
 }
 
 #if (DM_ODM_SUPPORT_TYPE == ODM_CE)
-u8 phydm_rate2ss(void *dm_void, u8 rate_idx)
+static u8 phydm_rate2ss(void *dm_void, u8 rate_idx)
 {
 	u8 ret = 0xff;
 	u8 i, j;
@@ -1693,7 +1693,7 @@ u8 phydm_rate2ss(void *dm_void, u8 rate_idx)
 	return ret;
 }
 
-u8 phydm_rate2plcp(void *dm_void, u8 rate_idx)
+static u8 phydm_rate2plcp(void *dm_void, u8 rate_idx)
 {
 	u8 rate2ss = 0;
 	u8 ltftime = 0;
@@ -1737,7 +1737,7 @@ u8 phydm_get_plcp(void *dm_void, u16 macid)
 }
 #endif
 
-void phydm_ra_common_info_update(void *dm_void)
+static void phydm_ra_common_info_update(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ra_table *ra_tab = &dm->dm_ra_table;
@@ -1785,7 +1785,7 @@ void phydm_rrsr_set_register(void *dm_void, u32 rrsr_val)
 	odm_set_mac_reg(dm, R_0x440, 0xfffff, rrsr_val);
 }
 
-void phydm_masked_rrsr_set_register(void *dm_void, u32 rrsr_val)
+static void phydm_masked_rrsr_set_register(void *dm_void, u32 rrsr_val)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ra_table *ra_tab = &dm->dm_ra_table;
@@ -1797,7 +1797,7 @@ void phydm_masked_rrsr_set_register(void *dm_void, u32 rrsr_val)
 	odm_set_mac_reg(dm, R_0x440, 0xfffff, rrsr_val);
 }
 
-void phydm_rrsr_mask(void *dm_void)
+static void phydm_rrsr_mask(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ra_table *ra = &dm->dm_ra_table;

--- a/hal/phydm/phydm_rssi_monitor.c
+++ b/hal/phydm/phydm_rssi_monitor.c
@@ -32,7 +32,7 @@
 
 #ifdef PHYDM_SUPPORT_RSSI_MONITOR
 
-void phydm_rssi_monitor_h2c(void *dm_void, u8 macid)
+static void phydm_rssi_monitor_h2c(void *dm_void, u8 macid)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct ra_table *ra_t = &dm->dm_ra_table;
@@ -95,7 +95,7 @@ void phydm_rssi_monitor_h2c(void *dm_void, u8 macid)
 	}
 }
 
-void phydm_calculate_rssi_min_max(void *dm_void)
+static void phydm_calculate_rssi_min_max(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct cmn_sta_info *sta;

--- a/hal/phydm/rtl8822c/phydm_hal_api8822c.c
+++ b/hal/phydm/rtl8822c/phydm_hal_api8822c.c
@@ -90,7 +90,7 @@ void phydm_txagc_tab_buff_show_8822c(struct dm_struct *dm)
 #endif
 
 __odm_func__
-void phydm_bb_reset_8822c(struct dm_struct *dm)
+static void phydm_bb_reset_8822c(struct dm_struct *dm)
 {
 	if (*dm->mp_mode) 
 		return;
@@ -101,7 +101,7 @@ void phydm_bb_reset_8822c(struct dm_struct *dm)
 }
 
 __odm_func__
-void phydm_bb_reset_no_3wires_8822c(struct dm_struct *dm)
+static void phydm_bb_reset_no_3wires_8822c(struct dm_struct *dm)
 {
 	/* Disable bbrstb 3-wires */
 	odm_set_bb_reg(dm, R_0x1c90, BIT(8), 0x0);
@@ -137,7 +137,7 @@ boolean phydm_chk_pkg_set_valid_8822c(struct dm_struct *dm,
 }
 
 __odm_func__
-void phydm_igi_toggle_8822c(struct dm_struct *dm)
+static void phydm_igi_toggle_8822c(struct dm_struct *dm)
 {
 /*
  * @Toggle IGI to force BB HW send 3-wire-cmd and will let RF HW enter RX mode.
@@ -155,7 +155,7 @@ void phydm_igi_toggle_8822c(struct dm_struct *dm)
 }
 
 __odm_func__
-u32 phydm_check_bit_mask_8822c(u32 bit_mask, u32 data_original, u32 data)
+static u32 phydm_check_bit_mask_8822c(u32 bit_mask, u32 data_original, u32 data)
 {
 	u8 bit_shift = 0;
 
@@ -201,7 +201,7 @@ u32 config_phydm_read_rf_reg_8822c(struct dm_struct *dm, enum rf_path path,
 }
 
 __odm_func__
-boolean
+static boolean
 config_phydm_direct_write_rf_reg_8822c(struct dm_struct *dm, enum rf_path path,
 				       u32 reg_addr, u32 bit_mask, u32 data)
 {
@@ -898,7 +898,7 @@ phydm_get_rx_path_en_setting_8822c(struct dm_struct *dm,
 }
 
 __odm_func__
-void
+static void
 phydm_config_cck_tx_path_8822c(struct dm_struct *dm, enum bb_path tx_path)
 {
 	if (tx_path == BB_PATH_A)
@@ -912,7 +912,7 @@ phydm_config_cck_tx_path_8822c(struct dm_struct *dm, enum bb_path tx_path)
 }
 
 __odm_func__
-boolean
+static boolean
 phydm_config_cck_rx_path_8822c(struct dm_struct *dm, enum bb_path rx_path)
 {
 	boolean set_result = PHYDM_SET_FAIL;
@@ -960,7 +960,7 @@ phydm_config_cck_rx_path_8822c(struct dm_struct *dm, enum bb_path rx_path)
 }
 
 __odm_func__
-void
+static void
 phydm_config_ofdm_tx_path_8822c(struct dm_struct *dm, enum bb_path tx_path_2ss,
 				enum bb_path tx_path_sel_1ss)
 {
@@ -994,7 +994,7 @@ phydm_config_ofdm_tx_path_8822c(struct dm_struct *dm, enum bb_path tx_path_2ss,
 }
 
 __odm_func__
-void
+static void
 phydm_config_ofdm_rx_path_8822c(struct dm_struct *dm, enum bb_path rx_path)
 {
 	u32 ofdm_rx = 0x0;
@@ -1073,7 +1073,7 @@ void phydm_config_tx_path_8822c(struct dm_struct *dm, enum bb_path tx_path_2ss,
 }
 
 __odm_func__
-void phydm_config_rx_path_8822c(struct dm_struct *dm, enum bb_path rx_path)
+static void phydm_config_rx_path_8822c(struct dm_struct *dm, enum bb_path rx_path)
 {
 	/* @CCK RX antenna mapping */
 	phydm_config_cck_rx_path_8822c(dm, rx_path);
@@ -1087,7 +1087,7 @@ void phydm_config_rx_path_8822c(struct dm_struct *dm, enum bb_path rx_path)
 }
 
 __odm_func__
-void
+static void
 phydm_set_rf_mode_table_8822c(struct dm_struct *dm,
 			      enum bb_path tx_path_mode_table,
 			      enum bb_path rx_path)
@@ -1125,7 +1125,7 @@ phydm_set_rf_mode_table_8822c(struct dm_struct *dm,
 }
 
 __odm_func__
-void
+static void
 phydm_rfe_8822c(struct dm_struct *dm, enum bb_path path)
 {
 	u8 rfe_type = dm->rfe_type;
@@ -1280,7 +1280,7 @@ config_phydm_trx_mode_8822c(struct dm_struct *dm, enum bb_path tx_path_en,
 	return true;
 }
 
-void phydm_cck_rxiq_8822c(struct dm_struct *dm, u8 set_type)
+static void phydm_cck_rxiq_8822c(struct dm_struct *dm, u8 set_type)
 {
 	PHYDM_DBG(dm, ODM_PHY_CONFIG, "%s ======>\n", __func__);
 
@@ -1305,7 +1305,7 @@ config_phydm_switch_band_8822c(struct dm_struct *dm, u8 central_ch)
 }
 
 __odm_func__
-void
+static void
 phydm_cck_tx_shaping_filter_8822c(struct dm_struct *dm, u8 central_ch)
 {
 	/* @CCK TX filter parameters */
@@ -1347,7 +1347,7 @@ phydm_cck_tx_shaping_filter_8822c(struct dm_struct *dm, u8 central_ch)
 }
 
 __odm_func__
-void
+static void
 phydm_cck_agc_tab_sel_8822c(struct dm_struct *dm, u8 table)
 {
 	odm_set_bb_reg(dm, R_0x18ac, 0xf000, table);
@@ -1355,7 +1355,7 @@ phydm_cck_agc_tab_sel_8822c(struct dm_struct *dm, u8 table)
 }
 
 __odm_func__
-void
+static void
 phydm_ofdm_agc_tab_sel_8822c(struct dm_struct *dm, u8 table)
 {
 	struct phydm_dig_struct *dig_tab = &dm->dm_dig_table;
@@ -1373,7 +1373,7 @@ phydm_ofdm_agc_tab_sel_8822c(struct dm_struct *dm, u8 table)
 }
 
 __odm_func__
-void
+static void
 phydm_sco_trk_fc_setting_8822c(struct dm_struct *dm, u8 central_ch)
 {
 	if (central_ch == 13 || central_ch == 14) {
@@ -1407,7 +1407,7 @@ phydm_sco_trk_fc_setting_8822c(struct dm_struct *dm, u8 central_ch)
 }
 
 __odm_func__
-void
+static void
 phydm_tx_dfir_setting_8822c(struct dm_struct *dm, u8 central_ch)
 {
 	if (central_ch <= 14) {
@@ -1421,7 +1421,7 @@ phydm_tx_dfir_setting_8822c(struct dm_struct *dm, u8 central_ch)
 }
 
 __odm_func__
-void phydm_set_manual_nbi_8822c(struct dm_struct *dm, boolean en_manual_nbi,
+static void phydm_set_manual_nbi_8822c(struct dm_struct *dm, boolean en_manual_nbi,
 				int tone_idx)
 {
 	if (en_manual_nbi) {
@@ -1450,7 +1450,7 @@ void phydm_set_manual_nbi_8822c(struct dm_struct *dm, boolean en_manual_nbi,
 }
 
 __odm_func__
-void phydm_set_auto_nbi_8822c(struct dm_struct *dm, boolean en_auto_nbi)
+static void phydm_set_auto_nbi_8822c(struct dm_struct *dm, boolean en_auto_nbi)
 {
 	if (en_auto_nbi) {
 		/*enable auto nbi detection*/
@@ -1463,7 +1463,7 @@ void phydm_set_auto_nbi_8822c(struct dm_struct *dm, boolean en_auto_nbi)
 }
 
 __odm_func__
-void phydm_csi_mask_enable_8822c(struct dm_struct *dm, boolean enable)
+static void phydm_csi_mask_enable_8822c(struct dm_struct *dm, boolean enable)
 {
 	if (enable)
 		odm_set_bb_reg(dm, R_0xc0c, BIT(3), 0x1);
@@ -1472,7 +1472,7 @@ void phydm_csi_mask_enable_8822c(struct dm_struct *dm, boolean enable)
 }
 
 __odm_func__
-void phydm_set_csi_mask_8822c(struct dm_struct *dm, u32 tone_idx)
+static void phydm_set_csi_mask_8822c(struct dm_struct *dm, u32 tone_idx)
 {
 	u32 table_addr = tone_idx >> 1;
 
@@ -1493,7 +1493,7 @@ void phydm_set_csi_mask_8822c(struct dm_struct *dm, u32 tone_idx)
 }
 
 __odm_func__
-void phydm_clean_all_csi_mask_8822c(struct dm_struct *dm)
+static void phydm_clean_all_csi_mask_8822c(struct dm_struct *dm)
 {
 	u8 i = 0;
 
@@ -1512,7 +1512,7 @@ void phydm_clean_all_csi_mask_8822c(struct dm_struct *dm)
 }
 
 __odm_func__
-void phydm_spur_eliminate_8822c(struct dm_struct *dm, u8 central_ch)
+static void phydm_spur_eliminate_8822c(struct dm_struct *dm, u8 central_ch)
 {
 	phydm_set_auto_nbi_8822c(dm, false);
 	phydm_csi_mask_enable_8822c(dm, true);
@@ -1534,7 +1534,7 @@ void phydm_spur_eliminate_8822c(struct dm_struct *dm, u8 central_ch)
 }
 
 __odm_func__
-void phydm_set_dis_dpd_by_rate_8822c(struct dm_struct *dm, u16 bitmask)
+static void phydm_set_dis_dpd_by_rate_8822c(struct dm_struct *dm, u16 bitmask)
 {
 	/* bit(0) : ofdm 6m*/
 	/* bit(1) : ofdm 9m*/
@@ -2084,7 +2084,7 @@ u16 phydm_get_dis_dpd_by_rate_8822c(struct dm_struct *dm)
 }
 
 __odm_func__
-void phydm_cck_pd_init_8822c(struct dm_struct *dm)
+static void phydm_cck_pd_init_8822c(struct dm_struct *dm)
 {
 	struct phydm_iot_center	*iot_table = &dm->iot_table;
 

--- a/hal/phydm/rtl8822c/phydm_regconfig8822c.c
+++ b/hal/phydm/rtl8822c/phydm_regconfig8822c.c
@@ -95,7 +95,7 @@ void odm_config_rf_radio_b_8822c(struct dm_struct *dm, u32 addr, u32 data)
 		  addr, data);
 }
 
-void phydm_agc_lower_bound_8822c(struct dm_struct *dm, u32 addr, u32 data)
+static void phydm_agc_lower_bound_8822c(struct dm_struct *dm, u32 addr, u32 data)
 {
 	u8 rxbb_gain = (u8)(data & 0x0000001f);
 	u8 mp_gain = (u8)((data & 0x003f0000) >> 16);
@@ -114,7 +114,7 @@ void phydm_agc_lower_bound_8822c(struct dm_struct *dm, u32 addr, u32 data)
 	}
 }
 
-void phydm_agc_store_8822c(struct dm_struct *dm, u32 addr, u32 data)
+static void phydm_agc_store_8822c(struct dm_struct *dm, u32 addr, u32 data)
 {
 	u16 rf_gain = (u16)(data & 0x000003ff);
 	u8 mp_gain = (u8)((data & 0x003f0000) >> 16);

--- a/hal/phydm/rtl8822c/phydm_rtl8822c.c
+++ b/hal/phydm/rtl8822c/phydm_rtl8822c.c
@@ -26,7 +26,7 @@
 #include "../phydm_precomp.h"
 
 #if (RTL8822C_SUPPORT)
-void phydm_dynamic_switch_htstf_agc_8822c(struct dm_struct *dm)
+static void phydm_dynamic_switch_htstf_agc_8822c(struct dm_struct *dm)
 {
 	u8 ndp_valid_cnt = 0;
 	u8 ndp_valid_cnt_diff = 0;

--- a/hal/phydm/txbf/phydm_hal_txbf_api.c
+++ b/hal/phydm/txbf/phydm_hal_txbf_api.c
@@ -461,7 +461,7 @@ void phydm_txbf_rfmode(void *dm_void, u8 su_bfee_cnt, u8 mu_bfee_cnt)
 #endif
 }
 
-void phydm_mu_rsoml_reset(void *dm_void)
+static void phydm_mu_rsoml_reset(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct phydm_bf_rate_info_jgr3 *rateinfo = &dm->bf_rate_info_jgr3;

--- a/hal/rtl8822c/rtl8822c_ops.c
+++ b/hal/rtl8822c/rtl8822c_ops.c
@@ -1361,7 +1361,7 @@ static void set_opmode_port1(PADAPTER adapter, u8 mode)
 #endif /* CONFIG_CONCURRENT_MODE */
 }
 #endif /* !CONFIG_MI_WITH_MBSSID_CAM */
-void hw_tsf_reset(_adapter *adapter)
+static void hw_tsf_reset(_adapter *adapter)
 {
 	u8 hw_port = rtw_hal_get_port(adapter);
 	u32 tsf_rst_addr = 0;
@@ -1377,7 +1377,7 @@ void hw_tsf_reset(_adapter *adapter)
 	tsf_rst_bit = port_cfg[hw_port].tsf_rst_bit;
 	rtw_write8(adapter, tsf_rst_addr, tsf_rst_bit);
 }
-void hw_set_ta(_adapter *adapter, u8 hw_port, u8 *val)
+static void hw_set_ta(_adapter *adapter, u8 hw_port, u8 *val)
 {
 	u8 idx = 0;
 	u32 reg = port_cfg[hw_port].ta;
@@ -1388,7 +1388,7 @@ void hw_set_ta(_adapter *adapter, u8 hw_port, u8 *val)
 	RTW_INFO("%s("ADPT_FMT") hw port -%d TA: "MAC_FMT"\n",
 		__func__, ADPT_ARG(adapter), hw_port, MAC_ARG(val));
 }
-void hw_set_aid(_adapter *adapter, u8 hw_port, u8 aid)
+static void hw_set_aid(_adapter *adapter, u8 hw_port, u8 aid)
 {
 	rtw_write16(adapter, port_cfg[hw_port].ps_aid, (0xF800 | aid));
 	RTW_INFO("%s("ADPT_FMT") hw port -%d AID: %d\n",
@@ -2716,7 +2716,7 @@ static u8 hw_var_get_bcn_valid(PADAPTER adapter)
 	return ret;
 }
 
-void rtl8822c_read_wmmedca_reg(PADAPTER adapter, u16 *vo_params, u16 *vi_params, u16 *be_params, u16 *bk_params)
+static void rtl8822c_read_wmmedca_reg(PADAPTER adapter, u16 *vo_params, u16 *vi_params, u16 *be_params, u16 *bk_params)
 {
 	u8 vo_reg_params[4];
 	u8 vi_reg_params[4];
@@ -3037,7 +3037,7 @@ u8 rtl8822c_sethaldefvar(PADAPTER adapter, HAL_DEF_VARIABLE variable, void *pval
 
 	return bResult;
 }
-void rtl8822c_ra_info_dump(_adapter *padapter, void *sel)
+static void rtl8822c_ra_info_dump(_adapter *padapter, void *sel)
 {
 	u8 mac_id;
 	struct sta_info *psta;

--- a/hal/rtl8822c/rtl8822c_phy.c
+++ b/hal/rtl8822c/rtl8822c_phy.c
@@ -983,7 +983,7 @@ static void switch_chnl_and_set_bw_by_fw(PADAPTER adapter, u8 switch_band)
  * Description:
  *	Set channel & bandwidth & offset
  */
-void rtl8822c_switch_chnl_and_set_bw(PADAPTER adapter)
+static void rtl8822c_switch_chnl_and_set_bw(PADAPTER adapter)
 {
 	PHAL_DATA_TYPE hal = GET_HAL_DATA(adapter);
 	struct dm_struct *p_dm_odm = &hal->odmpriv;
@@ -1090,7 +1090,7 @@ void rtl8822c_switch_chnl_and_set_bw(PADAPTER adapter)
  *	CenterFrequencyIndex1	center channel index
  */
 
-void rtl8822c_handle_sw_chnl_and_set_bw(
+static void rtl8822c_handle_sw_chnl_and_set_bw(
 	PADAPTER Adapter, u8 bSwitchChannel, u8 bSetBandWidth,
 	u8 ChannelNum, enum channel_width ChnlWidth, u8 ChnlOffsetOf40MHz,
 	u8 ChnlOffsetOf80MHz, u8 CenterFrequencyIndex1)
@@ -2006,7 +2006,7 @@ static void _reset_beamformee_mu(PADAPTER adapter, struct beamformee_entry *bfee
 	RTW_INFO("%s: Clear MU BFee entry(%d) HW setting\n", __FUNCTION__, idx);
 }
 
-void rtl8822c_phy_bf_reset_all(PADAPTER adapter)
+static void rtl8822c_phy_bf_reset_all(PADAPTER adapter)
 {
 	struct beamforming_info *info;
 	u8 i, val8;

--- a/include/hal_data.h
+++ b/include/hal_data.h
@@ -344,7 +344,7 @@ struct txpwr_lmt_ent {
 		[MAX_TX_COUNT];
 #endif
 
-	char regd_name[0];
+	char regd_name[];
 };
 #endif /* CONFIG_TXPWR_LIMIT */
 

--- a/include/rtw_rf.h
+++ b/include/rtw_rf.h
@@ -203,7 +203,7 @@ struct regd_exc_ent {
 	_list list;
 	char country[2];
 	u8 domain;
-	char regd_name[0];
+	char regd_name[];
 };
 
 void dump_regd_exc_list(void *sel, struct rf_ctl_t *rfctl);

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -424,7 +424,7 @@ static void rtw_get_chbw_from_nl80211_channel_type(struct ieee80211_channel *cha
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29)) */
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0))
-bool rtw_cfg80211_allow_ch_switch_notify(_adapter *adapter)
+static bool rtw_cfg80211_allow_ch_switch_notify(_adapter *adapter)
 {
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0))
 	if ((!MLME_IS_AP(adapter))
@@ -501,31 +501,31 @@ exit:
 }
 #endif /* (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)) */
 
-void rtw_2g_channels_init(struct ieee80211_channel *channels)
+static void rtw_2g_channels_init(struct ieee80211_channel *channels)
 {
 	_rtw_memcpy((void *)channels, (void *)rtw_2ghz_channels, sizeof(rtw_2ghz_channels));
 }
 
-void rtw_5g_channels_init(struct ieee80211_channel *channels)
+static void rtw_5g_channels_init(struct ieee80211_channel *channels)
 {
 	_rtw_memcpy((void *)channels, (void *)rtw_5ghz_a_channels, sizeof(rtw_5ghz_a_channels));
 }
 
-void rtw_2g_rates_init(struct ieee80211_rate *rates)
+static void rtw_2g_rates_init(struct ieee80211_rate *rates)
 {
 	_rtw_memcpy(rates, rtw_g_rates,
 		sizeof(struct ieee80211_rate) * RTW_G_RATES_NUM
 	);
 }
 
-void rtw_5g_rates_init(struct ieee80211_rate *rates)
+static void rtw_5g_rates_init(struct ieee80211_rate *rates)
 {
 	_rtw_memcpy(rates, rtw_a_rates,
 		sizeof(struct ieee80211_rate) * RTW_A_RATES_NUM
 	);
 }
 
-struct ieee80211_supported_band *rtw_spt_band_alloc(BAND_TYPE band)
+static struct ieee80211_supported_band *rtw_spt_band_alloc(BAND_TYPE band)
 {
 	struct ieee80211_supported_band *spt_band = NULL;
 	int n_channels, n_bitrates;
@@ -568,7 +568,7 @@ exit:
 	return spt_band;
 }
 
-void rtw_spt_band_free(struct ieee80211_supported_band *spt_band)
+static void rtw_spt_band_free(struct ieee80211_supported_band *spt_band)
 {
 	u32 size = 0;
 
@@ -656,7 +656,7 @@ static const struct ieee80211_txrx_stypes
 };
 #endif
 
-NDIS_802_11_NETWORK_INFRASTRUCTURE nl80211_iftype_to_rtw_network_type(enum nl80211_iftype type)
+static NDIS_802_11_NETWORK_INFRASTRUCTURE nl80211_iftype_to_rtw_network_type(enum nl80211_iftype type)
 {
 	switch (type) {
 	case NL80211_IFTYPE_ADHOC:
@@ -691,7 +691,7 @@ NDIS_802_11_NETWORK_INFRASTRUCTURE nl80211_iftype_to_rtw_network_type(enum nl802
 	}
 }
 
-u32 nl80211_iftype_to_rtw_mlme_state(enum nl80211_iftype type)
+static u32 nl80211_iftype_to_rtw_mlme_state(enum nl80211_iftype type)
 {
 	switch (type) {
 	case NL80211_IFTYPE_ADHOC:
@@ -2388,7 +2388,7 @@ static int cfg80211_rtw_set_default_key(struct wiphy *wiphy,
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 30))
-int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
+static int cfg80211_rtw_set_default_mgmt_key(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0))
 	/* upstream 033fe322f585: set_default_mgmt_key takes wireless_dev * */
 	struct wireless_dev *wdev
@@ -2943,7 +2943,7 @@ void rtw_cfg80211_unlink_bss(_adapter *padapter, struct wlan_network *pnetwork)
 }
 
 /* if target wps scan ongoing, target_ssid is filled */
-int rtw_cfg80211_is_target_wps_scan(struct cfg80211_scan_request *scan_req, struct cfg80211_ssid *target_ssid)
+static int rtw_cfg80211_is_target_wps_scan(struct cfg80211_scan_request *scan_req, struct cfg80211_ssid *target_ssid)
 {
 	int ret = 0;
 
@@ -5762,7 +5762,7 @@ const char *_nl80211_mesh_power_mode_str[] = {
 #define nl80211_mesh_power_mode_str(_p) ((_p <= NL80211_MESH_POWER_MAX) ? _nl80211_mesh_power_mode_str[_p] : _nl80211_mesh_power_mode_str[0])
 #endif
 
-void dump_station_parameters(void *sel, struct wiphy *wiphy, const struct station_parameters *params)
+static void dump_station_parameters(void *sel, struct wiphy *wiphy, const struct station_parameters *params)
 {
 #if DBG_RTW_CFG80211_STA_PARAM
 	if (params->supported_rates_len) {
@@ -6265,7 +6265,7 @@ exit:
 	return ret;
 }
 
-struct sta_info *rtw_sta_info_get_by_idx(struct sta_priv *pstapriv, const int idx, u8 *asoc_list_num)
+static struct sta_info *rtw_sta_info_get_by_idx(struct sta_priv *pstapriv, const int idx, u8 *asoc_list_num)
 {
 	_list	*phead, *plist;
 	struct sta_info *psta = NULL;
@@ -10404,7 +10404,7 @@ int rtw_hostapd_acs_dump_survey(struct wiphy *wiphy, struct net_device *netdev, 
 
 #if (KERNEL_VERSION(4, 17, 0) <= LINUX_VERSION_CODE) \
     || defined(CONFIG_KERNEL_PATCH_EXTERNAL_AUTH)
-int cfg80211_rtw_external_auth(struct wiphy *wiphy, struct net_device *dev,
+static int cfg80211_rtw_external_auth(struct wiphy *wiphy, struct net_device *dev,
 	struct cfg80211_external_auth_params *params)
 {
 	PADAPTER padapter = (_adapter *)rtw_netdev_priv(dev);

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -12382,7 +12382,7 @@ static iw_handler rtw_private_handler[] = {
 	rtw_test,						/* 0x1D */
 };
 
-#if WIRELESS_EXT >= 17
+#if defined(CONFIG_WIRELESS_EXT) && (WIRELESS_EXT >= 17)
 static struct iw_statistics *rtw_get_wireless_stats(struct net_device *dev)
 {
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1027,7 +1027,7 @@ static void rtw_regsty_load_tx_ac_lifetime(struct registry_priv *regsty)
 }
 #endif
 
-void rtw_regsty_load_target_tx_power(struct registry_priv *regsty)
+static void rtw_regsty_load_target_tx_power(struct registry_priv *regsty)
 {
 	int path, rs;
 	int *target_tx_pwr;
@@ -1585,7 +1585,7 @@ static struct net_device_stats *rtw_net_get_stats(struct net_device *pnetdev)
 static const u16 rtw_1d_to_queue[8] = { 2, 3, 3, 2, 1, 1, 0, 0 };
 
 /* Given a data frame determine the 802.1p/1d tag to use. */
-unsigned int rtw_classify8021d(struct sk_buff *skb)
+static unsigned int rtw_classify8021d(struct sk_buff *skb)
 {
 	unsigned int dscp;
 
@@ -1728,7 +1728,7 @@ void rtw_ndev_notifier_unregister(void)
 	unregister_netdevice_notifier(&rtw_ndev_notifier);
 }
 
-int rtw_ndev_init(struct net_device *dev)
+static int rtw_ndev_init(struct net_device *dev)
 {
 	_adapter *adapter = rtw_netdev_priv(dev);
 
@@ -1741,7 +1741,7 @@ int rtw_ndev_init(struct net_device *dev)
 	return 0;
 }
 
-void rtw_ndev_uninit(struct net_device *dev)
+static void rtw_ndev_uninit(struct net_device *dev)
 {
 	_adapter *adapter = rtw_netdev_priv(dev);
 
@@ -1801,7 +1801,7 @@ int rtw_init_netdev_name(struct net_device *pnetdev, const char *ifname)
 	return 0;
 }
 
-void rtw_hook_if_ops(struct net_device *ndev)
+static void rtw_hook_if_ops(struct net_device *ndev)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 29))
 	ndev->netdev_ops = &rtw_netdev_ops;
@@ -1883,7 +1883,7 @@ struct net_device *rtw_init_netdev(_adapter *old_padapter)
 	return pnetdev;
 }
 
-int rtw_os_ndev_alloc(_adapter *adapter)
+static int rtw_os_ndev_alloc(_adapter *adapter)
 {
 	int ret = _FAIL;
 	struct net_device *ndev = NULL;
@@ -1934,7 +1934,7 @@ void rtw_os_ndev_free(_adapter *adapter)
 	}
 }
 
-int rtw_os_ndev_register(_adapter *adapter, const char *name)
+static int rtw_os_ndev_register(_adapter *adapter, const char *name)
 {
 	struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 	int ret = _SUCCESS;
@@ -2081,7 +2081,7 @@ void rtw_os_ndev_deinit(_adapter *adapter)
 	rtw_os_ndev_free(adapter);
 }
 
-int rtw_os_ndevs_alloc(struct dvobj_priv *dvobj)
+static int rtw_os_ndevs_alloc(struct dvobj_priv *dvobj)
 {
 	int i, status = _SUCCESS;
 	_adapter *adapter;
@@ -2133,7 +2133,7 @@ int rtw_os_ndevs_alloc(struct dvobj_priv *dvobj)
 	return status;
 }
 
-void rtw_os_ndevs_free(struct dvobj_priv *dvobj)
+static void rtw_os_ndevs_free(struct dvobj_priv *dvobj)
 {
 	int i;
 	_adapter *adapter = NULL;
@@ -2265,7 +2265,7 @@ void rtw_stop_drv_threads(_adapter *padapter)
 	rtw_hal_stop_thread(padapter);
 }
 
-u8 rtw_init_default_value(_adapter *padapter)
+static u8 rtw_init_default_value(_adapter *padapter)
 {
 	u8 ret  = _SUCCESS;
 	struct registry_priv *pregistrypriv = &padapter->registrypriv;
@@ -3454,7 +3454,7 @@ void rtw_inetaddr_notifier_unregister(void)
 #endif
 }
 
-int rtw_os_ndevs_register(struct dvobj_priv *dvobj)
+static int rtw_os_ndevs_register(struct dvobj_priv *dvobj)
 {
 	int i, status = _SUCCESS;
 	struct registry_priv *regsty = dvobj_to_regsty(dvobj);
@@ -4897,7 +4897,7 @@ int rtw_suspend_ap_wow(_adapter *padapter)
 #endif /* #ifdef CONFIG_AP_WOWLAN */
 
 
-int rtw_suspend_normal(_adapter *padapter)
+static int rtw_suspend_normal(_adapter *padapter)
 {
 	int ret = _SUCCESS;
 
@@ -5311,7 +5311,7 @@ exit:
 }
 #endif /* #ifdef CONFIG_APWOWLAN */
 
-void rtw_mi_resume_process_normal(_adapter *padapter)
+static void rtw_mi_resume_process_normal(_adapter *padapter)
 {
 	int i;
 	_adapter *iface;
@@ -5340,7 +5340,7 @@ void rtw_mi_resume_process_normal(_adapter *padapter)
 	}
 }
 
-int rtw_resume_process_normal(_adapter *padapter)
+static int rtw_resume_process_normal(_adapter *padapter)
 {
 	struct net_device *pnetdev;
 	struct pwrctrl_priv *pwrpriv;

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -364,7 +364,7 @@ int rtw_android_cmdstr_to_num(char *cmdstr)
 	return cmd_num;
 }
 
-int rtw_android_get_rssi(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_rssi(struct net_device *net, char *command, int total_len)
 {
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(net);
 	struct	mlme_priv	*pmlmepriv = &(padapter->mlmepriv);
@@ -379,7 +379,7 @@ int rtw_android_get_rssi(struct net_device *net, char *command, int total_len)
 	return bytes_written;
 }
 
-int rtw_android_get_link_speed(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_link_speed(struct net_device *net, char *command, int total_len)
 {
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(net);
 	int bytes_written = 0;
@@ -391,7 +391,7 @@ int rtw_android_get_link_speed(struct net_device *net, char *command, int total_
 	return bytes_written;
 }
 
-int rtw_android_get_macaddr(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_macaddr(struct net_device *net, char *command, int total_len)
 {
 	int bytes_written = 0;
 
@@ -399,7 +399,7 @@ int rtw_android_get_macaddr(struct net_device *net, char *command, int total_len
 	return bytes_written;
 }
 
-int rtw_android_set_country(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_country(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *country_code = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_COUNTRY]) + 1;
@@ -410,7 +410,7 @@ int rtw_android_set_country(struct net_device *net, char *command, int total_len
 	return (ret == _SUCCESS) ? 0 : -1;
 }
 
-int rtw_android_get_p2p_dev_addr(struct net_device *net, char *command, int total_len)
+static int rtw_android_get_p2p_dev_addr(struct net_device *net, char *command, int total_len)
 {
 	int bytes_written = 0;
 
@@ -421,7 +421,7 @@ int rtw_android_get_p2p_dev_addr(struct net_device *net, char *command, int tota
 	return bytes_written;
 }
 
-int rtw_android_set_block_scan(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_block_scan(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *block_value = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_BLOCK_SCAN]) + 1;
@@ -433,7 +433,7 @@ int rtw_android_set_block_scan(struct net_device *net, char *command, int total_
 	return 0;
 }
 
-int rtw_android_set_block(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_block(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *block_value = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_BLOCK]) + 1;
@@ -445,7 +445,7 @@ int rtw_android_set_block(struct net_device *net, char *command, int total_len)
 	return 0;
 }
 
-int rtw_android_setband(struct net_device *net, char *command, int total_len)
+static int rtw_android_setband(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	char *arg = command + strlen(android_wifi_cmd_str[ANDROID_WIFI_CMD_SETBAND]) + 1;
@@ -458,7 +458,7 @@ int rtw_android_setband(struct net_device *net, char *command, int total_len)
 	return (ret == _SUCCESS) ? 0 : -1;
 }
 
-int rtw_android_getband(struct net_device *net, char *command, int total_len)
+static int rtw_android_getband(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	int bytes_written = 0;
@@ -469,7 +469,7 @@ int rtw_android_getband(struct net_device *net, char *command, int total_len)
 }
 
 #ifdef CONFIG_WFD
-int rtw_android_set_miracast_mode(struct net_device *net, char *command, int total_len)
+static int rtw_android_set_miracast_mode(struct net_device *net, char *command, int total_len)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(net);
 	struct wifi_display_info *wfd_info = &adapter->wfd_info;
@@ -505,7 +505,7 @@ exit:
 }
 #endif /* CONFIG_WFD */
 
-int get_int_from_command(char *pcmd)
+static int get_int_from_command(char *pcmd)
 {
 	int i = 0;
 

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -143,7 +143,7 @@ int dbg_rtw_cfg80211_vendor_cmd_reply(struct sk_buff *skb
 	dbg_rtw_cfg80211_vendor_cmd_reply(skb, MSTAT_FUNC_CFG_VENDOR | MSTAT_TYPE_SKB, __FUNCTION__, __LINE__)
 #else
 
-struct sk_buff *rtw_cfg80211_vendor_event_alloc(
+static struct sk_buff *rtw_cfg80211_vendor_event_alloc(
 	struct wiphy *wiphy, struct wireless_dev *wdev, int len, int event_id, gfp_t gfp)
 {
 	struct sk_buff *skb;
@@ -249,7 +249,7 @@ static int rtw_cfgvendor_send_cmd_reply(struct wiphy *wiphy,
 #define MAX_FEATURE_SET_CONCURRRENT_GROUPS  3
 
 #include <hal_data.h>
-int rtw_dev_get_feature_set(struct net_device *dev)
+static int rtw_dev_get_feature_set(struct net_device *dev)
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
 	HAL_DATA_TYPE *HalData = GET_HAL_DATA(adapter);
@@ -286,7 +286,7 @@ int rtw_dev_get_feature_set(struct net_device *dev)
 	return feature_set;
 }
 
-int *rtw_dev_get_feature_set_matrix(struct net_device *dev, int *num)
+static int *rtw_dev_get_feature_set_matrix(struct net_device *dev, int *num)
 {
 	int feature_set_full, mem_needed;
 	int *ret;

--- a/os_dep/linux/rtw_proc.c
+++ b/os_dep/linux/rtw_proc.c
@@ -501,7 +501,7 @@ static int proc_get_sdio_dbg(struct seq_file *m, void *v)
 void rtw_sdio_dbg_reg_free(struct dvobj_priv *d);
 #endif /* DBG_SDIO >= 2 */
 
-ssize_t proc_set_sdio_dbg(struct file *file, const char __user *buffer,
+static ssize_t proc_set_sdio_dbg(struct file *file, const char __user *buffer,
 			  size_t count, loff_t *pos, void *data)
 {
 #if (DBG_SDIO >= 2)
@@ -664,7 +664,7 @@ ssize_t proc_set_led_config(struct file *file, const char __user *buffer, size_t
 #endif /* CONFIG_RTW_LED */
 
 #ifdef CONFIG_AP_MODE
-int proc_get_aid_status(struct seq_file *m, void *v)
+static int proc_get_aid_status(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -674,7 +674,7 @@ int proc_get_aid_status(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_aid_status(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_aid_status(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -707,7 +707,7 @@ ssize_t proc_set_aid_status(struct file *file, const char __user *buffer, size_t
 	return count;
 }
 
-int proc_get_ap_isolate(struct seq_file *m, void *v)
+static int proc_get_ap_isolate(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -717,7 +717,7 @@ int proc_get_ap_isolate(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_ap_isolate(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_ap_isolate(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -1432,7 +1432,7 @@ static int proc_get_macaddr_acl(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_macaddr_acl(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_macaddr_acl(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -1733,7 +1733,7 @@ static ssize_t proc_set_dfs_test_case(struct file *file, const char __user *buff
 	return count;
 }
 
-ssize_t proc_set_update_non_ocp(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_update_non_ocp(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -1769,7 +1769,7 @@ exit:
 	return count;
 }
 
-ssize_t proc_set_radar_detect(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_radar_detect(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -1890,7 +1890,7 @@ exit:
 #endif /* CONFIG_DFS_MASTER */
 
 #ifdef CONFIG_80211N_HT
-int proc_get_rx_ampdu_size_limit(struct seq_file *m, void *v)
+static int proc_get_rx_ampdu_size_limit(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -1900,7 +1900,7 @@ int proc_get_rx_ampdu_size_limit(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_rx_ampdu_size_limit(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_rx_ampdu_size_limit(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -2947,7 +2947,7 @@ static ssize_t proc_set_tx_gain_offset(struct file *file, const char __user *buf
 #endif /* CONFIG_RF_POWER_TRIM */
 
 #ifdef CONFIG_BT_COEXIST
-ssize_t proc_set_btinfo_evt(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_btinfo_evt(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
@@ -3069,7 +3069,7 @@ static int btreg_parse_str(char const *input, u8 *type, u16 *addr, u16 *val)
 	return 0;
 }
 
-int proc_get_btreg_read(struct seq_file *m, void *v)
+static int proc_get_btreg_read(struct seq_file *m, void *v)
 {
 	struct net_device *dev;
 	PADAPTER padapter;
@@ -3092,7 +3092,7 @@ int proc_get_btreg_read(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_btreg_read(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_btreg_read(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	PADAPTER padapter;
@@ -3143,7 +3143,7 @@ exit:
 	return count;
 }
 
-int proc_get_btreg_write(struct seq_file *m, void *v)
+static int proc_get_btreg_write(struct seq_file *m, void *v)
 {
 	struct net_device *dev;
 	PADAPTER padapter;
@@ -3170,7 +3170,7 @@ int proc_get_btreg_write(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_btreg_write(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_btreg_write(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	PADAPTER padapter;
@@ -3225,7 +3225,7 @@ exit:
 	return count;
 }
 
-int proc_get_btc_reduce_wl_txpwr(struct seq_file *m, void *v)
+static int proc_get_btc_reduce_wl_txpwr(struct seq_file *m, void *v)
 {
 	struct net_device *dev;
 	PADAPTER padapter;
@@ -3240,7 +3240,7 @@ int proc_get_btc_reduce_wl_txpwr(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_btc_reduce_wl_txpwr(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_btc_reduce_wl_txpwr(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	PADAPTER padapter;
@@ -3301,7 +3301,7 @@ int proc_get_mbid_cam_cache(struct seq_file *m, void *v)
 }
 #endif /* CONFIG_MBSSID_CAM */
 
-int proc_get_mac_addr(struct seq_file *m, void *v)
+static int proc_get_mac_addr(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(dev);
@@ -3691,7 +3691,7 @@ static ssize_t proc_set_napi_th(struct file *file, const char __user *buffer, si
 #endif /* CONFIG_RTW_NAPI_DYNAMIC */
 
 
-ssize_t proc_set_dynamic_agg_enable(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_dynamic_agg_enable(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *dev = data;
 	_adapter *padapter = (_adapter *)rtw_netdev_priv(dev);
@@ -4410,7 +4410,7 @@ exit:
 }
 #endif /* CONFIG_RTW_TPT_MODE */
 
-int proc_get_cur_beacon_keys(struct seq_file *m, void *v)
+static int proc_get_cur_beacon_keys(struct seq_file *m, void *v)
 {
 	struct net_device *dev = m->private;
 	_adapter *adapter = rtw_netdev_priv(dev);
@@ -4991,7 +4991,7 @@ ssize_t proc_set_odm_adaptivity(struct file *file, const char __user *buffer, si
 static char *phydm_msg = NULL;
 #define PHYDM_MSG_LEN	80*24*4
 
-int proc_get_phydm_cmd(struct seq_file *m, void *v)
+static int proc_get_phydm_cmd(struct seq_file *m, void *v)
 {
 	struct net_device *netdev;
 	PADAPTER padapter;
@@ -5018,7 +5018,7 @@ int proc_get_phydm_cmd(struct seq_file *m, void *v)
 	return 0;
 }
 
-ssize_t proc_set_phydm_cmd(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
+static ssize_t proc_set_phydm_cmd(struct file *file, const char __user *buffer, size_t count, loff_t *pos, void *data)
 {
 	struct net_device *netdev;
 	PADAPTER padapter;
@@ -5138,7 +5138,7 @@ static const struct rtw_proc_ops rtw_odm_proc_sseq_fops = {
 #endif
 };
 
-struct proc_dir_entry *rtw_odm_proc_init(struct net_device *dev)
+static struct proc_dir_entry *rtw_odm_proc_init(struct net_device *dev)
 {
 	struct proc_dir_entry *dir_odm = NULL;
 	struct proc_dir_entry *entry = NULL;
@@ -5182,7 +5182,7 @@ exit:
 	return dir_odm;
 }
 
-void rtw_odm_proc_deinit(_adapter	*adapter)
+static void rtw_odm_proc_deinit(_adapter	*adapter)
 {
 	struct proc_dir_entry *dir_odm = NULL;
 	int i;

--- a/os_dep/linux/sdio_intf.c
+++ b/os_dep/linux/sdio_intf.c
@@ -800,7 +800,7 @@ static void sd_intf_stop(PADAPTER padapter)
 PADAPTER g_test_adapter = NULL;
 #endif /* RTW_SUPPORT_PLATFORM_SHUTDOWN */
 
-_adapter *rtw_sdio_primary_adapter_init(struct dvobj_priv *dvobj)
+static _adapter *rtw_sdio_primary_adapter_init(struct dvobj_priv *dvobj)
 {
 	int status = _FAIL;
 	PADAPTER padapter = NULL;

--- a/os_dep/linux/xmit_linux.c
+++ b/os_dep/linux/xmit_linux.c
@@ -374,7 +374,7 @@ void rtw_os_wake_queue_at_free_stainfo(_adapter *padapter, int *qcnt_freed)
 }
 
 #ifdef CONFIG_TX_MCAST2UNI
-int rtw_mlcst2unicst(_adapter *padapter, struct sk_buff *skb)
+static int rtw_mlcst2unicst(_adapter *padapter, struct sk_buff *skb)
 {
 	struct	sta_priv *pstapriv = &padapter->stapriv;
 	struct xmit_priv *pxmitpriv = &padapter->xmitpriv;

--- a/platform/platform_ops.c
+++ b/platform/platform_ops.c
@@ -12,6 +12,8 @@
  * more details.
  *
  *****************************************************************************/
+#include "platform_ops.h"
+
 #ifndef CONFIG_PLATFORM_OPS
 /*
  * Return:


### PR DESCRIPTION
- use C99 flexible array member for regd_name (from `char regd_name[0]` to `char regd_name[]`)
- mark file-private functions static
- fix `rtw_get_wireless_stats` -Wunused-function
- fix -Wmissing-prototypes for platform_wifi_power_on/off (TODO: remove not needed platform code)