### PR TITLE
Fix -Wempty-body warnings (62 -> 0)

### DIFF
--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -2300,12 +2300,12 @@ unsigned int OnAuth(_adapter *padapter, union recv_frame *precv_frame)
 					pstapriv->tbtx_asoc_list_cnt--;
 				#endif
 				if (pstat->expire_to > 0)
-					;/* TODO: STA re_auth within expire_to */
+					{ }/* TODO: STA re_auth within expire_to */
 			}
 			_exit_critical_bh(&pstapriv->asoc_list_lock, &irqL);
 
 			if (seq == 1)
-				; /* TODO: STA re_auth and auth timeout */
+				{ } /* TODO: STA re_auth and auth timeout */
 
 		}
 	}

--- a/hal/phydm/halrf/halrf_debug.h
+++ b/hal/phydm/halrf/halrf_debug.h
@@ -98,7 +98,7 @@ static __inline void RF_DBG(struct dm_struct *dm, int comp, char *fmt, ...)
 {
 }
 #else
-#define RF_DBG(dm, comp, fmt, args...)
+#define RF_DBG(dm, comp, fmt, args...) do {} while (0)
 #endif
 
 #endif /*#if DBG*/

--- a/hal/phydm/phydm_debug.h
+++ b/hal/phydm/phydm_debug.h
@@ -242,7 +242,7 @@ static __inline void PHYDM_DBG_F(PDM_ODM_T dm, int comp, char *fmt, ...)
 
 #elif defined(DM_ODM_CE_MAC80211_V2)
 
-#define PHYDM_DBG(dm, comp, fmt, args...)
+#define PHYDM_DBG(dm, comp, fmt, args...) do {} while (0)
 #define PHYDM_DBG_F(dm, comp, fmt, args...)
 #define PHYDM_PRINT_ADDR(dm, comp, title_str, addr)
 
@@ -307,7 +307,7 @@ static __inline void PHYDM_DBG_F(struct dm_struct *dm, int comp, char *fmt, ...)
 {
 }
 #else
-#define PHYDM_DBG(dm, comp, fmt, args...)
+#define PHYDM_DBG(dm, comp, fmt, args...) do {} while (0)
 #define PHYDM_DBG_F(dm, comp, fmt, args...)
 #endif
 #define PHYDM_PRINT_ADDR(dm, comp, title_str, ptr)

--- a/include/rtw_debug.h
+++ b/include/rtw_debug.h
@@ -279,7 +279,7 @@ extern uint rtw_drv_log_level;
 #ifdef CONFIG_DBG_COUNTER
 	#define DBG_COUNTER(counter) counter++
 #else
-	#define DBG_COUNTER(counter)
+	#define DBG_COUNTER(counter) do {} while (0)
 #endif
 
 void dump_drv_version(void *sel);


### PR DESCRIPTION
Eliminates all 62 `-Wempty-body` warnings in an x86_64 / v6.12.91 / gcc13 build. Standalone, config-independent change — the first of the smaller split PRs from the #23 discussion.

## Cause
The debug macros `RF_DBG`, `PHYDM_DBG` and `DBG_COUNTER` expand to nothing in their debug-disabled branches. Call sites such as `if (cond) RF_DBG(...);` then collapse to `if (cond) ;`, which gcc reports as `-Wempty-body`.

## Fix
- Give the empty macro branches a `do {} while (0)` body so they stay valid single statements. A bare `{}` is not enough: there are real `if (...) MACRO(...); else MACRO(...);` sites (e.g. `DBG_COUNTER` in `recv_linux.c`), and `{}` breaks them with a dangling `else`. `do {} while (0)` is the standard form for statement-like macros ([kernel coding-style §12](https://www.kernel.org/doc/html/latest/process/coding-style.html), [GCC CPP "Swallowing the Semicolon"](https://gcc.gnu.org/onlinedocs/cpp/Swallowing-the-Semicolon.html)).
- Brace two genuinely empty `if` bodies in `rtw_mlme_ext.c`.

No behavior change when debug is enabled — the non-empty branches are untouched.
