### PR TITLE
Fix -Wmissing-prototypes via self-includes (29 functions)

### DIFF
--- a/core/rtw_sdio.c
+++ b/core/rtw_sdio.c
@@ -15,6 +15,7 @@
 #define _RTW_SDIO_C_
 
 #include <drv_types.h>		/* struct dvobj_priv and etc. */
+#include <rtw_sdio.h>
 #include <drv_types_sdio.h>	/* RTW_SDIO_ADDR_CMD52_GEN */
 
 /*

--- a/core/rtw_swcrypto.c
+++ b/core/rtw_swcrypto.c
@@ -13,6 +13,7 @@
  *
  *****************************************************************************/
 #include <drv_types.h>
+#include <rtw_swcrypto.h>
 #include <hal_data.h>
 #include <aes.h>
 #include <aes_siv.h>

--- a/hal/rtl8822c/sdio/rtl8822cs_halinit.c
+++ b/hal/rtl8822c/sdio/rtl8822cs_halinit.c
@@ -18,6 +18,7 @@
 #include <hal_data.h>		/* HAL_DATA_TYPE */
 #include "../../hal_halmac.h"	/* rtw_halmac_query_tx_page_num() */
 #include "../rtl8822c.h"	/* rtl8822c_hal_init(), rtl8822c_phy_init_haldm() and etc. */
+#include "rtl8822cs.h"		/* rtl8822cs_* prototypes */
 
 #ifdef CONFIG_FWLPS_IN_IPS
 static u8 fw_ips_leave(struct _ADAPTER *a)

--- a/hal/rtl8822c/sdio/rtl8822cs_recv.c
+++ b/hal/rtl8822c/sdio/rtl8822cs_recv.c
@@ -18,6 +18,7 @@
 #include <hal_data.h>		/* HAL_DATA_TYPE */
 #include "../../hal_halmac.h"	/* BIT_ACRC32_8822C and etc. */
 #include "../rtl8822c.h"	/* rtl8822c_rxdesc2attribute(), rtl8822c_c2h_handler_no_io() */
+#include "rtl8822cs.h"		/* rtl8822cs_* prototypes */
 
 
 static s32 initrecvbuf(struct recv_buf *precvbuf, PADAPTER adapter)

--- a/hal/rtl8822c/sdio/rtl8822cs_xmit.c
+++ b/hal/rtl8822c/sdio/rtl8822cs_xmit.c
@@ -18,6 +18,7 @@
 #include <hal_data.h>		/* HAL_DATA_TYPE */
 #include "../../hal_halmac.h"	/* rtw_halmac_sdio_tx_allowed() and etc. */
 #include "../rtl8822c.h"	/* rtl8822c_update_txdesc() and etc. */
+#include "rtl8822cs.h"		/* rtl8822cs_* prototypes */
 
 
 static s32 dequeue_writeport(PADAPTER adapter)

--- a/include/custom_gpio.h
+++ b/include/custom_gpio.h
@@ -13,7 +13,7 @@
  *
  *****************************************************************************/
 #ifndef __CUSTOM_GPIO_H__
-#define __CUSTOM_GPIO_H___
+#define __CUSTOM_GPIO_H__
 
 #include <drv_conf.h>
 #include <osdep_service.h>

--- a/os_dep/linux/custom_gpio_linux.c
+++ b/os_dep/linux/custom_gpio_linux.c
@@ -13,6 +13,7 @@
  *
  *****************************************************************************/
 #include "drv_types.h"
+#include <custom_gpio.h>
 
 #ifdef CONFIG_PLATFORM_SPRD
 


### PR DESCRIPTION
First split of #23, broken into small separately-verifiable pieces as
@adeepn requested.

Several source files define functions that are already declared in their
own headers but never include them, so under KCFLAGS=-Werror gcc reports
-Wmissing-prototypes at each definition. The fix is to include the
matching header:

- hal/rtl8822c/sdio/{rtl8822cs_halinit,rtl8822cs_recv,rtl8822cs_xmit}.c → rtl8822cs.h — 16
- core/rtw_sdio.c → rtw_sdio.h — 5
- core/rtw_swcrypto.c → rtw_swcrypto.h — 6
- os_dep/linux/custom_gpio_linux.c → custom_gpio.h — 2

The custom_gpio.h self-include also needs a one-line fix to that header's
include guard, which defined __CUSTOM_GPIO_H___ (one extra underscore)
instead of __CUSTOM_GPIO_H__; without it a second include under
CONFIG_SDIO_HCI + CONFIG_PLATFORM_SPRD (pulled in via drv_types_sdio.h)
would re-parse enum cust_gpio_modes and fail to compile. That guard fix
is the first commit, before the self-include.

This clears 29 of the 59 -Wmissing-prototypes warnings with no functional
change. The functions keep external linkage, so it cannot introduce
-Wunused-function.

Build-verified under three configurations, all clean (29 warnings gone,
no new errors, -Wunused-function count unchanged):
- x86_64, distro .config, KBUILD_MODPOST_WARN=1 KCFLAGS=-Werror, kernel v6.12.93 (your CI setup)
- Armbian meson64 edge, arm64, kernel 7.0.12
- Armbian current, arm64, kernel 6.18.35

The remaining 30 (prototypes that are missing or guarded out) will follow
as separate PRs.
