### PR TITLE
Fix -Wmissing-prototypes: declare cross-file functions in their headers

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -24,6 +24,7 @@
 
 #if 1	/* rtw_wifi_driver */
 	#include <drv_types.h>
+	#include <rtw_br_ext.h>
 #else	/* rtw_wifi_driver */
 	#include "./8192cd_cfg.h"
 

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -7547,7 +7547,7 @@ s32 dump_mgntframe_and_wait_ack(_adapter *padapter, struct xmit_frame *pmgntfram
 }
 
 
-int update_hidden_ssid(u8 *ies, u32 ies_len, u8 hidden_ssid_mode)
+static int update_hidden_ssid(u8 *ies, u32 ies_len, u8 hidden_ssid_mode)
 {
 	u8 *ssid_ie;
 	sint ssid_len_ori;

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -15,6 +15,7 @@
 #define _RTW_RECV_C_
 
 #include <drv_types.h>
+#include <rtw_recv.h>
 #include <hal_data.h>
 
 #ifdef CONFIG_NEW_SIGNAL_STAT_PROCESS

--- a/hal/hal_dm.h
+++ b/hal/hal_dm.h
@@ -115,4 +115,5 @@ void rtw_phydm_pwr_tracking_directly(_adapter *adapter);
 void rtw_phydm_trx_cfg(_adapter *adapter, bool tx_1ss);
 #endif
 int rtw_phydm_rfe_ctrl_gpio(_adapter *adapter, u8 gpio_num);
+void record_ra_info(void *p_dm_void, u8 macid, struct cmn_sta_info *p_sta, u64 ra_mask);
 #endif /* __HAL_DM_H__ */

--- a/hal/phydm/halrf/halphyrf_ce.h
+++ b/hal/phydm/halrf/halphyrf_ce.h
@@ -120,4 +120,7 @@ u8 odm_get_right_chnl_place_for_iqk(u8 chnl);
 void phydm_rf_init(void *dm_void);
 void phydm_rf_watchdog(void *dm_void);
 
+struct dm_struct;
+void odm_iq_calibrate(struct dm_struct *dm);
+
 #endif /*__HALPHYRF_H__*/

--- a/hal/phydm/halrf/halrf_powertracking_ce.h
+++ b/hal/phydm/halrf/halrf_powertracking_ce.h
@@ -327,4 +327,7 @@ void odm_txpowertracking_thermal_meter_check(
 
 #endif
 
+u8 get_swing_index(void *dm_void);
+u8 get_cck_swing_index(void *dm_void);
+
 #endif /*__HALRF_POWER_TRACKING_H__*/

--- a/hal/phydm/halrf/halrf_psd.h
+++ b/hal/phydm/halrf/halrf_psd.h
@@ -47,4 +47,7 @@ halrf_psd_init_query(
 	u32 average,
 	u32 buf_size);
 
+struct dm_struct;
+void halrf_psd(struct dm_struct *dm, u32 point, u32 start_point, u32 stop_point, u32 average);
+
 #endif /*#__HALRF_PSD_H__*/

--- a/hal/phydm/halrf/rtl8822c/halrf_dpk_8822c.h
+++ b/hal/phydm/halrf/rtl8822c/halrf_dpk_8822c.h
@@ -83,6 +83,8 @@ void dpk_c2h_report_transfer_8822c(
 	u8 	*buf,
 	u8	buf_size);
 
+void _dpk_get_coef_8822c(void *dm_void, u8 path);
+
 #endif /* RTL8822C_SUPPORT */
 
 #endif /*#ifndef __HALRF_DPK_8822C_H__*/

--- a/hal/phydm/halrf/rtl8822c/halrf_iqk_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_iqk_8822c.c
@@ -2514,6 +2514,7 @@ static void _iqk_fail_count_8822c(
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]All/Fail = %d %d\n", dm->n_iqk_cnt, dm->n_iqk_fail_cnt);
 }
 
+#if (DM_ODM_SUPPORT_TYPE & ODM_AP)
 static void _iqk_iqk_fail_report_8822c(
 	struct dm_struct *dm)
 {
@@ -2537,6 +2538,7 @@ static void _iqk_iqk_fail_report_8822c(
 #endif
 	}
 }
+#endif
 
 static void _iqk_backup_mac_bb_8822c(
 	struct dm_struct *dm,

--- a/hal/phydm/halrf/rtl8822c/halrf_iqk_8822c.h
+++ b/hal/phydm/halrf/rtl8822c/halrf_iqk_8822c.h
@@ -84,6 +84,9 @@ void iqk_info_rsvd_page_8822c(void *dm_void, u8 *buf, u32 *buf_size);
 void iqk_power_save_8822c(void *dm_void, boolean is_power_save);
 
 
+struct dm_struct;
+void _iq_calibrate_8822c_init(struct dm_struct *dm);
+
 #else /* (RTL8822C_SUPPORT == 0)*/
 
 #define phy_iq_calibrate_8822c(_pdm_void, clear, segment_iqk)

--- a/hal/phydm/phydm_rainfo.h
+++ b/hal/phydm/phydm_rainfo.h
@@ -296,4 +296,5 @@ void phydm_ra_mask_watchdog(void *dm_void);
 void odm_refresh_basic_rate_mask(
 	void *dm_void);
 #endif
+void phydm_fw_fix_rate(void *dm_void, u8 en, u8 macid, u8 bw, u8 rate);
 #endif /*@#ifndef __PHYDMRAINFO_H__*/

--- a/include/osdep_intf.h
+++ b/include/osdep_intf.h
@@ -81,6 +81,13 @@ int rtw_ioctl(struct net_device *dev, struct ifreq *rq, int cmd);
 
 int rtw_init_netdev_name(struct net_device *pnetdev, const char *ifname);
 struct net_device *rtw_init_netdev(_adapter *padapter);
+int rtw_change_ifname(_adapter *padapter, const char *ifname);
+
+int pm_netdev_open(struct net_device *pnetdev, u8 bnormal);
+int pm_netdev_close(struct net_device *pnetdev, u8 bnormal);
+#ifdef CONFIG_BR_EXT
+void netdev_br_init(struct net_device *netdev);
+#endif
 
 void rtw_os_ndev_free(_adapter *adapter);
 int rtw_os_ndev_init(_adapter *adapter, const char *name);

--- a/include/rtw_br_ext.h
+++ b/include/rtw_br_ext.h
@@ -65,5 +65,10 @@ struct br_ext_info {
 };
 
 void nat25_db_cleanup(_adapter *priv);
+int nat25_handle_frame(_adapter *priv, struct sk_buff *skb);
+void dhcp_flag_bcast(_adapter *priv, struct sk_buff *skb);
+void *scdb_findEntry(_adapter *priv, unsigned char *macAddr, unsigned char *ipAddr);
+void nat25_db_expire(_adapter *priv);
+int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method);
 
 #endif /* _RTW_BR_EXT_H_ */

--- a/include/rtw_btcoex.h
+++ b/include/rtw_btcoex.h
@@ -414,6 +414,9 @@ u32 rtw_btcoex_GetDBG(PADAPTER, u8 *pStrBuf, u32 bufSize);
 u8 rtw_btcoex_IncreaseScanDeviceNum(PADAPTER);
 u8 rtw_btcoex_IsBtLinkExist(PADAPTER);
 void rtw_btcoex_pta_off_on_notify(PADAPTER padapter, u8 bBTON);
+void rtw_btcoex_SetBtPatchVersion(PADAPTER padapter, u16 btHciVer, u16 btPatchVer);
+void rtw_btcoex_SetHciVersion(PADAPTER  padapter, u16 hciVersion);
+void rtw_btcoex_StackUpdateProfileInfo(void);
 
 #ifdef CONFIG_RF4CE_COEXIST
 void rtw_btcoex_SetRf4ceLinkState(PADAPTER padapter, u8 state);
@@ -421,9 +424,6 @@ u8 rtw_btcoex_GetRf4ceLinkState(PADAPTER padapter);
 #endif
 
 #ifdef CONFIG_BT_COEXIST_SOCKET_TRX
-void rtw_btcoex_SetBtPatchVersion(PADAPTER padapter, u16 btHciVer, u16 btPatchVer);
-void rtw_btcoex_SetHciVersion(PADAPTER  padapter, u16 hciVersion);
-void rtw_btcoex_StackUpdateProfileInfo(void);
 void rtw_btcoex_init_socket(_adapter *padapter);
 void rtw_btcoex_close_socket(_adapter *padapter);
 void rtw_btcoex_dump_tx_msg(u8 *tx_msg, u8 len, u8 *msg_name);

--- a/include/rtw_mlme.h
+++ b/include/rtw_mlme.h
@@ -974,6 +974,9 @@ extern void rtw_free_assoc_resources(_adapter *adapter, u8 lock_scanned_queue);
 extern void rtw_indicate_disconnect(_adapter *adapter, u16 reason, u8 locally_generated);
 extern void rtw_indicate_connect(_adapter *adapter);
 void rtw_indicate_scan_done(_adapter *padapter, bool aborted);
+void indicate_wx_scan_complete_event(_adapter *padapter);
+void rtw_indicate_wx_assoc_event(_adapter *padapter);
+void rtw_indicate_wx_disassoc_event(_adapter *padapter);
 
 void rtw_drv_scan_by_self(_adapter *padapter, u8 reason);
 void rtw_scan_wait_completed(_adapter *adapter);

--- a/include/rtw_mlme_ext.h
+++ b/include/rtw_mlme_ext.h
@@ -1114,7 +1114,7 @@ struct rtw_cmd {
 #ifdef CONFIG_RTW_MESH
 extern u8 rtw_mesh_set_plink_state_cmd_hdl(_adapter *adapter, u8 *parmbuf);
 #else
-u8 rtw_mesh_set_plink_state_cmd_hdl(_adapter *adapter, u8 *parmbuf) { return H2C_CMD_FAIL; };
+static u8 rtw_mesh_set_plink_state_cmd_hdl(_adapter *adapter, u8 *parmbuf) { return H2C_CMD_FAIL; };
 #endif
 
 struct rtw_cmd wlancmds[] = {

--- a/include/rtw_mp.h
+++ b/include/rtw_mp.h
@@ -933,6 +933,7 @@ int rtw_mp_lck(struct net_device *dev,
 int rtw_mp_get_tsside(struct net_device *dev,
 		struct iw_request_info *info,
 		struct iw_point *wrqu, char *extra);
+u8 MgntQuery_NssTxRate(u16 Rate);
 int rtw_mp_set_tsside(struct net_device *dev,
 		struct iw_request_info *info,
 		struct iw_point *wrqu, char *extra);

--- a/include/rtw_pwrctrl.h
+++ b/include/rtw_pwrctrl.h
@@ -568,6 +568,7 @@ void rtw_wow_lps_level_decide(_adapter *adapter, u8 wow_en);
 #ifdef CONFIG_RESUME_IN_WORKQUEUE
 void rtw_resume_in_workqueue(struct pwrctrl_priv *pwrpriv);
 #endif /* CONFIG_RESUME_IN_WORKQUEUE */
+int rtw_resume_process(_adapter *padapter);
 
 #if defined(CONFIG_HAS_EARLYSUSPEND) || defined(CONFIG_ANDROID_POWER)
 bool rtw_is_earlysuspend_registered(struct pwrctrl_priv *pwrpriv);

--- a/include/rtw_recv.h
+++ b/include/rtw_recv.h
@@ -825,4 +825,6 @@ u8 adapter_allow_bmc_data_rx(_adapter *adapter);
 s32 pre_recv_entry(union recv_frame *precvframe, u8 *pphy_status);
 void count_rx_stats(_adapter *padapter, union recv_frame *prframe, struct sta_info *sta);
 
+sint recv_decache(union recv_frame *precv_frame);
+sint validate_recv_mgnt_frame(PADAPTER padapter, union recv_frame *precv_frame);
 #endif

--- a/include/rtw_xmit.h
+++ b/include/rtw_xmit.h
@@ -1030,8 +1030,8 @@ extern void rtw_amsdu_cancel_timer(_adapter *padapter, u8 priority);
 extern s32 rtw_xmitframe_coalesce_amsdu(_adapter *padapter, struct xmit_frame *pxmitframe, struct xmit_frame *pxmitframe_queue);	
 extern s32 check_amsdu(struct xmit_frame *pxmitframe);
 extern s32 check_amsdu_tx_support(_adapter *padapter);
-extern struct xmit_frame *rtw_get_xframe(struct xmit_priv *pxmitpriv, int *num_frame);
 #endif
+extern struct xmit_frame *rtw_get_xframe(struct xmit_priv *pxmitpriv, int *num_frame);
 
 #ifdef DBG_TXBD_DESC_DUMP
 void rtw_tx_desc_backup(_adapter *padapter, struct xmit_frame *pxmitframe, u8 desc_size, u8 hwq);


### PR DESCRIPTION
Companion to #27, covering the missing-prototype warnings that the self-include approach in #27 doesn't reach. Where #27 has files include their own header, this declares the **cross-file** (non-file-local) functions in their existing headers, and relocates a few prototypes whose `#ifdef` guard didn't match the definition.

- `core/` — add missing prototypes for br_ext / recv / mlme_ext functions; relocate mis-guarded prototypes to match their definitions; make the `CONFIG_RTW_MESH=n` stub `static`.
- `os_dep/`, `hal/phydm/` — declare cross-file RF / MP / calibration and helper functions in their headers.
- also guards one unused helper: `_iqk_iqk_fail_report_8822c` is compiled only for AP builds (`DM_ODM_SUPPORT_TYPE & ODM_AP`), matching its sole caller — clears a `-Wunused-function` under the default build.

**Depends on #27 — best merged after it.** On its own, the os_dep functions still report `-Wmissing-prototypes` under the CI's `make defconfig` (they need #27's include-guard fix to become visible); together with #27 the module builds with 0 `-Wmissing-prototypes`. No functional change.
