### PR TITLE
Fix -Wunused-function: guard config-only functions with their #ifdef (18)

### DIFF
--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -3269,6 +3269,7 @@ unsigned int OnAtim(_adapter *padapter, union recv_frame *precv_frame)
 	return _SUCCESS;
 }
 
+#ifdef CONFIG_SPCT_CH_SWITCH
 static unsigned int on_action_spct_ch_switch(_adapter *padapter, struct sta_info *psta, u8 *ies, uint ies_len)
 {
 	unsigned int ret = _FAIL;
@@ -3325,6 +3326,7 @@ static unsigned int on_action_spct_ch_switch(_adapter *padapter, struct sta_info
 exit:
 	return ret;
 }
+#endif /* CONFIG_SPCT_CH_SWITCH */
 
 unsigned int on_action_spct(_adapter *padapter, union recv_frame *precv_frame)
 {
@@ -12469,6 +12471,7 @@ When station does not receive any packet in MAX_CONTINUAL_NORXPACKET_COUNT*2 sec
 recipient station will teardown the block ack by issuing DELBA frame.
 
 *********************************************************************/
+#ifdef CONFIG_ISSUE_DELBA_WHEN_NO_TRAFFIC 
 static void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_timer)
 {
 	int	i = 0;
@@ -12506,6 +12509,7 @@ static void rtw_delba_check(_adapter *padapter, struct sta_info *psta, u8 from_t
 		}
 	}
 }
+#endif /* CONFIG_ISSUE_DELBA_WHEN_NO_TRAFFIC  */
 
 
 static u8 chk_ap_is_alive(_adapter *padapter, struct sta_info *psta)

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -4958,6 +4958,7 @@ void rtw_hal_set_input_gpio(_adapter *padapter, u8 index)
 
 #endif
 
+#ifdef CONFIG_WOWLAN
 static void rtw_hal_set_FwAoacRsvdPage_cmd(PADAPTER padapter, PRSVDPAGE_LOC rsvdpageloc)
 {
 	struct	pwrctrl_priv *pwrpriv = adapter_to_pwrctl(padapter);
@@ -5019,6 +5020,7 @@ static void rtw_hal_set_FwAoacRsvdPage_cmd(PADAPTER padapter, PRSVDPAGE_LOC rsvd
 #endif /* CONFIG_PNO_SUPPORT */
 #endif /* CONFIG_WOWLAN */
 }
+#endif /* CONFIG_WOWLAN */
 
 #ifdef DBG_FW_DEBUG_MSG_PKT
 void rtw_hal_set_fw_dbg_msg_pkt_rsvd_page_cmd(PADAPTER padapter, PRSVDPAGE_LOC rsvdpageloc)

--- a/hal/hal_dm.c
+++ b/hal/hal_dm.c
@@ -106,6 +106,7 @@ void rtw_phydm_iqk_trigger(_adapter *adapter)
 }
 #endif
 
+#ifdef CONFIG_DBG_RF_CAL
 static void rtw_phydm_iqk_trigger_dbg(_adapter *adapter, bool recovery, bool clear, bool segment)
 {
 	struct dm_struct *p_dm_odm = adapter_to_phydm(adapter);
@@ -116,12 +117,15 @@ static void rtw_phydm_iqk_trigger_dbg(_adapter *adapter, bool recovery, bool cle
 		halrf_iqk_trigger(p_dm_odm, recovery);
 #endif
 }
+#endif /* CONFIG_DBG_RF_CAL */
+#ifdef CONFIG_DBG_RF_CAL
 static void rtw_phydm_lck_trigger(_adapter *adapter)
 {
 	struct dm_struct *p_dm_odm = adapter_to_phydm(adapter);
 
 	halrf_lck_trigger(p_dm_odm);
 }
+#endif /* CONFIG_DBG_RF_CAL */
 #ifdef CONFIG_DBG_RF_CAL
 void rtw_hal_iqk_test(_adapter *adapter, bool recovery, bool clear, bool segment)
 {

--- a/hal/phydm/halrf/halrf.c
+++ b/hal/phydm/halrf/halrf.c
@@ -460,6 +460,7 @@ void halrf_iqk_dbg(void *dm_void)
 #endif
 }
 
+#if (RTL8822B_SUPPORT == 1 || RTL8821C_SUPPORT == 1)
 static void halrf_lck_dbg(struct dm_struct *dm)
 {
 	RF_DBG(dm, DBG_RF_IQK, "%-20s\n", "====== LCK Info ======");
@@ -471,6 +472,7 @@ static void halrf_lck_dbg(struct dm_struct *dm)
 	RF_DBG(dm, DBG_RF_IQK, "%-20s: %llu %s\n", "progressing_time",
 	       dm->rf_calibrate_info.lck_progressing_time, "(ms)");
 }
+#endif /* (RTL8822B_SUPPORT == 1 || RTL8821C_SUPPORT == 1) */
 void phydm_get_iqk_cfir(void *dm_void, u8 idx, u8 path, boolean debug)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;

--- a/hal/phydm/halrf/rtl8822c/halrf_dpk_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_dpk_8822c.c
@@ -1175,6 +1175,7 @@ static void _dpk_coef_write_8822c(
 	}
 }
 
+#if DPK_COEF_DBG_8822C
 static void _dpk_coef1_read_8822c(
 	void *dm_void,
 	u8 path)
@@ -1247,6 +1248,7 @@ static void _dpk_coef1_read_8822c(
 
 	odm_set_bb_reg(dm, 0x1b04 + path * 0x58, 0xf0000000, 0x0); /*disable manual coef*/
 }
+#endif /* DPK_COEF_DBG_8822C */
 
 static void _dpk_coef_default_8822c(
 	void *dm_void,

--- a/hal/phydm/phydm_api.c
+++ b/hal/phydm/phydm_api.c
@@ -406,6 +406,7 @@ static void phydm_config_trx_path_v2(void *dm_void, char input[][16], u32 *_used
 #endif
 }
 
+#if (RTL8192E_SUPPORT || RTL8812A_SUPPORT)
 static void phydm_config_trx_path_v1(void *dm_void, char input[][16], u32 *_used,
 			      char *output, u32 *_out_len)
 {
@@ -479,6 +480,7 @@ static void phydm_config_trx_path_v1(void *dm_void, char input[][16], u32 *_used
 	*_out_len = out_len;
 #endif
 }
+#endif /* (RTL8192E_SUPPORT || RTL8812A_SUPPORT) */
 
 void phydm_config_trx_path(void *dm_void, char input[][16], u32 *_used,
 			   char *output, u32 *_out_len)

--- a/hal/phydm/phydm_auto_dbg.c
+++ b/hal/phydm/phydm_auto_dbg.c
@@ -32,6 +32,7 @@
 
 #ifdef PHYDM_AUTO_DEGBUG
 
+#if (ODM_IC_11N_SERIES_SUPPORT == 1)
 static void phydm_check_hang_reset(
 	void *dm_void)
 {
@@ -43,6 +44,7 @@ static void phydm_check_hang_reset(
 	phydm_pause_dm_watchdog(dm, PHYDM_RESUME);
 	dm->debug_components &= (~ODM_COMP_API);
 }
+#endif /* (ODM_IC_11N_SERIES_SUPPORT == 1) */
 
 static void phydm_check_hang_init(
 	void *dm_void)

--- a/hal/phydm/phydm_dig.c
+++ b/hal/phydm/phydm_dig.c
@@ -234,6 +234,7 @@ static void phydm_fa_threshold_check(void *dm_void, boolean is_dfs_band)
 		  dig_t->fa_th[1], dig_t->fa_th[2]);
 }
 
+#if (RTL8822B_SUPPORT || RTL8197F_SUPPORT || RTL8192F_SUPPORT)
 static void phydm_set_big_jump_step(void *dm_void, u8 curr_igi)
 {
 #if (RTL8822B_SUPPORT || RTL8197F_SUPPORT || RTL8192F_SUPPORT)
@@ -264,6 +265,7 @@ static void phydm_set_big_jump_step(void *dm_void, u8 curr_igi)
 		  dig_t->big_jump_step1, big_jump_lmt);
 #endif
 }
+#endif /* (RTL8822B_SUPPORT || RTL8197F_SUPPORT || RTL8192F_SUPPORT) */
 
 #ifdef PHYDM_IC_JGR3_SERIES_SUPPORT
 static void phydm_write_dig_reg_jgr3(void *dm_void, u8 igi)
@@ -1235,6 +1237,7 @@ static void phydm_false_alarm_counter_reg_reset(void *dm_void)
 #endif /* @#if (ODM_IC_11AC_SERIES_SUPPORT) */
 }
 
+#if (ODM_IC_11N_SERIES_SUPPORT)
 static void phydm_false_alarm_counter_reg_hold(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -1255,6 +1258,7 @@ static void phydm_false_alarm_counter_reg_hold(void *dm_void)
 		odm_set_bb_reg(dm, R_0xa2c, BIT(14), 1);
 	}
 }
+#endif /* (ODM_IC_11N_SERIES_SUPPORT) */
 
 #if (ODM_IC_11N_SERIES_SUPPORT)
 void phydm_fa_cnt_statistics_n(void *dm_void)

--- a/hal/phydm/phydm_phystatus.c
+++ b/hal/phydm/phydm_phystatus.c
@@ -389,6 +389,7 @@ static void phydm_avg_phystatus_init(void *dm_void)
 	#endif
 }
 
+#if (ODM_IC_11N_SERIES_SUPPORT)
 static u8 phydm_get_signal_quality(struct phydm_phyinfo_struct *phy_info,
 			    struct dm_struct *dm,
 			    struct phy_status_rpt_8192cd *phy_sts)
@@ -411,6 +412,7 @@ static u8 phydm_get_signal_quality(struct phydm_phyinfo_struct *phy_info,
 
 	return result;
 }
+#endif /* (ODM_IC_11N_SERIES_SUPPORT) */
 
 static u8 phydm_pw_2_percent(s8 ant_power)
 {
@@ -653,11 +655,13 @@ phydm_evm_2_percent(s8 value)
 	return (u8)ret_val;
 }
 
+#if (RTL8197F_SUPPORT)
 static s8 phydm_cck_rssi_convert(struct dm_struct *dm, u16 lna_idx, u8 vga_idx)
 {
 	/*@phydm_get_cck_rssi_table_from_reg*/
 	return (dm->cck_lna_gain_table[lna_idx] - (vga_idx << 1));
 }
+#endif /* (RTL8197F_SUPPORT) */
 
 void phydm_get_cck_rssi_table_from_reg(struct dm_struct *dm)
 {
@@ -1244,6 +1248,7 @@ void phydm_reset_rssi_for_dm(struct dm_struct *dm, u8 station_id)
 
 #if (ODM_IC_11N_SERIES_SUPPORT || ODM_IC_11AC_SERIES_SUPPORT)
 
+#if (RTL8814A_SUPPORT == 1)
 static s32 phydm_get_rssi_8814_ofdm(struct dm_struct *dm, u8 *rssi_in)
 {
 	s32 rssi_avg;
@@ -1289,6 +1294,7 @@ static s32 phydm_get_rssi_8814_ofdm(struct dm_struct *dm, u8 *rssi_in)
 
 	return rssi_avg;
 }
+#endif /* (RTL8814A_SUPPORT == 1) */
 
 static void phydm_process_rssi_for_dm(struct dm_struct *dm,
 			       struct phydm_phyinfo_struct *phy_info,

--- a/hal/phydm/rtl8822c/phydm_hal_api8822c.c
+++ b/hal/phydm/rtl8822c/phydm_hal_api8822c.c
@@ -101,6 +101,7 @@ static void phydm_bb_reset_8822c(struct dm_struct *dm)
 }
 
 __odm_func__
+#if CONFIG_POWERSAVING
 static void phydm_bb_reset_no_3wires_8822c(struct dm_struct *dm)
 {
 	/* Disable bbrstb 3-wires */
@@ -113,6 +114,7 @@ static void phydm_bb_reset_no_3wires_8822c(struct dm_struct *dm)
 	/* Enable bbrstb 3-wires */
 	odm_set_bb_reg(dm, R_0x1c90, BIT(8), 0x1);
 }
+#endif /* CONFIG_POWERSAVING */
 
 __odm_func__
 boolean phydm_chk_pkg_set_valid_8822c(struct dm_struct *dm,

--- a/hal/rtl8822c/rtl8822c_ops.c
+++ b/hal/rtl8822c/rtl8822c_ops.c
@@ -1361,6 +1361,7 @@ static void set_opmode_port1(PADAPTER adapter, u8 mode)
 #endif /* CONFIG_CONCURRENT_MODE */
 }
 #endif /* !CONFIG_MI_WITH_MBSSID_CAM */
+#ifdef DBG_TSF_MONITOR
 static void hw_tsf_reset(_adapter *adapter)
 {
 	u8 hw_port = rtw_hal_get_port(adapter);
@@ -1377,6 +1378,8 @@ static void hw_tsf_reset(_adapter *adapter)
 	tsf_rst_bit = port_cfg[hw_port].tsf_rst_bit;
 	rtw_write8(adapter, tsf_rst_addr, tsf_rst_bit);
 }
+#endif /* DBG_TSF_MONITOR */
+#ifdef CONFIG_CLIENT_PORT_CFG
 static void hw_set_ta(_adapter *adapter, u8 hw_port, u8 *val)
 {
 	u8 idx = 0;
@@ -1388,12 +1391,15 @@ static void hw_set_ta(_adapter *adapter, u8 hw_port, u8 *val)
 	RTW_INFO("%s("ADPT_FMT") hw port -%d TA: "MAC_FMT"\n",
 		__func__, ADPT_ARG(adapter), hw_port, MAC_ARG(val));
 }
+#endif /* CONFIG_CLIENT_PORT_CFG */
+#ifdef CONFIG_CLIENT_PORT_CFG
 static void hw_set_aid(_adapter *adapter, u8 hw_port, u8 aid)
 {
 	rtw_write16(adapter, port_cfg[hw_port].ps_aid, (0xF800 | aid));
 	RTW_INFO("%s("ADPT_FMT") hw port -%d AID: %d\n",
 			__func__, ADPT_ARG(adapter), hw_port, aid);
 }
+#endif /* CONFIG_CLIENT_PORT_CFG */
 #ifdef CONFIG_CLIENT_PORT_CFG
 void rtw_hw_client_port_cfg(_adapter *adapter)
 {


### PR DESCRIPTION
Continues the -Werror cleanup (after #24/#25/#27/#28). With -Wmissing-prototypes now at 0, the remaining class is -Wunused-function: functions made `static` in #24 that are reachable only from call sites under a disabled chip/feature macro, so they are flagged in the default build.

This handles the subset whose sole caller sits under a config/chip guard — wrap each definition in the **same `#ifdef` as its caller**, so the function is compiled only when it can actually be used. Kernel-style `#endif /* COND */` comments.

Guards used:
- chip support: RTL8814A, RTL8192E|8812A, RTL8197F, RTL8822B|8821C, 8822B|8197F|8192F, ODM_IC_11N_SERIES_SUPPORT
- features: CONFIG_CLIENT_PORT_CFG, CONFIG_DBG_RF_CAL, CONFIG_ISSUE_DELBA_WHEN_NO_TRAFFIC, CONFIG_SPCT_CH_SWITCH, CONFIG_WOWLAN, CONFIG_POWERSAVING, DPK_COEF_DBG_8822C, DBG_TSF_MONITOR

No functional change — each guarded function was already uncompiled-or-unused in the default build.

Build-verified (x86_64, v7.1, `make defconfig` → CONFIG_WERROR=y): **-Wunused-function 71 → 53**, -Wmissing-prototypes 0, 0 errors.

The remaining -Wunused-function are genuinely dead / transitively-dead (no live caller) and will be handled separately (likely `__maybe_unused` or removal).