### PR TITLE
ci: check out the PR ref, not hard-coded tune_for_jethub

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -61,8 +61,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          ref: tune_for_jethub
       
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
The `build` job pinned `ref: tune_for_jethub` in `actions/checkout`, so `pull_request` runs checked out the **base branch** instead of the PR's code. The matrix therefore never validated the change under review — every PR's CI reflected `tune_for_jethub` as-is, not the PR.

Fix: drop the `ref`, letting `actions/checkout` use the event default — the PR merge ref for `pull_request`, the pushed commit for `push`, the default branch for `workflow_dispatch`.

No other change.