### PR TITLE
Fix -Wunused-function: mark genuinely-unused statics __maybe_unused (53)

### DIFF
--- a/core/crypto/ccmp.c
+++ b/core/crypto/ccmp.c
@@ -175,7 +175,7 @@ u8 * ccmp_decrypt(const u8 *tk, const struct ieee80211_hdr *hdr,
 }
 
 
-static void ccmp_get_pn(u8 *pn, const u8 *data)
+static void __maybe_unused ccmp_get_pn(u8 *pn, const u8 *data)
 {
 	pn[0] = data[7]; /* PN5 */
 	pn[1] = data[6]; /* PN4 */

--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -2847,7 +2847,7 @@ int rtw_ap_set_wep_key(_adapter *padapter, u8 *key, u8 keylen, int keyid, u8 set
 	return rtw_ap_set_key(padapter, key, alg, keyid, set_tx);
 }
 
-static u8 rtw_ap_bmc_frames_hdl(_adapter *padapter)
+static u8 __maybe_unused rtw_ap_bmc_frames_hdl(_adapter *padapter)
 {
 #define HIQ_XMIT_COUNTS (6)
 	_irqL irqL;

--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -4154,7 +4154,7 @@ struct btinfo {
 	u8 rsvd_7;
 };
 
-static void btinfo_evt_dump(void *sel, void *buf)
+static void __maybe_unused btinfo_evt_dump(void *sel, void *buf)
 {
 	struct btinfo *info = (struct btinfo *)buf;
 
@@ -5462,7 +5462,7 @@ exit:
 
 }
 
-static void rtw_getrttbl_cmd_cmdrsp_callback(_adapter	*padapter,  struct cmd_obj *pcmd)
+static void __maybe_unused rtw_getrttbl_cmd_cmdrsp_callback(_adapter	*padapter,  struct cmd_obj *pcmd)
 {
 
 	rtw_free_cmd_obj(pcmd);

--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -1179,7 +1179,7 @@ int SetTxPower(PADAPTER pAdapter)
 	return _TRUE;
 }
 
-static void SetTxAGCOffset(PADAPTER pAdapter, u32 ulTxAGCOffset)
+static void __maybe_unused SetTxAGCOffset(PADAPTER pAdapter, u32 ulTxAGCOffset)
 {
 	u32 TxAGCOffset_B, TxAGCOffset_C, TxAGCOffset_D, tmpAGC;
 

--- a/hal/hal_btcoex.c
+++ b/hal/hal_btcoex.c
@@ -5048,7 +5048,7 @@ static void EXhalbtcoutsrc_periodical(PBTC_COEXIST pBtCoexist)
 	/*	halbtcoutsrc_NormalLowPower(pBtCoexist); */
 }
 
-static void EXhalbtcoutsrc_dbg_control(PBTC_COEXIST pBtCoexist, u8 opCode, u8 opLen, u8 *pData)
+static void __maybe_unused EXhalbtcoutsrc_dbg_control(PBTC_COEXIST pBtCoexist, u8 opCode, u8 opLen, u8 *pData)
 {
 	if (!halbtcoutsrc_IsBtCoexistAvailable(pBtCoexist))
 		return;

--- a/hal/hal_dm.c
+++ b/hal/hal_dm.c
@@ -17,7 +17,7 @@
 #include <hal_data.h>
 
 /* A mapping from HalData to ODM. */
-static enum odm_board_type boardType(u8 InterfaceSel)
+static enum odm_board_type __maybe_unused boardType(u8 InterfaceSel)
 {
 	enum odm_board_type        board	= ODM_BOARD_DEFAULT;
 

--- a/hal/phydm/halrf/halrf.c
+++ b/hal/phydm/halrf/halrf.c
@@ -259,7 +259,7 @@ static void halrf_iqk_xym_show(struct dm_struct *dm, u8 xym_type)
 	}
 }
 
-static void halrf_iqk_xym_dump(void *dm_void)
+static void __maybe_unused halrf_iqk_xym_dump(void *dm_void)
 {
 	u32 tmp1, tmp2;
 	struct dm_struct *dm = (struct dm_struct *)dm_void;

--- a/hal/phydm/halrf/halrf_kfree.c
+++ b/hal/phydm/halrf/halrf_kfree.c
@@ -565,7 +565,7 @@ static void phydm_set_kfree_to_rf_8710b(void *dm_void, u8 e_rf_path, u8 data)
 			      BIT(15) | BIT(14))), e_rf_path);
 }
 
-static void phydm_clear_kfree_to_rf_8710b(void *dm_void, u8 e_rf_path, u8 data)
+static void __maybe_unused phydm_clear_kfree_to_rf_8710b(void *dm_void, u8 e_rf_path, u8 data)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	u32 gain_bmask = (BIT(18) | BIT(17) | BIT(16) | BIT(15) | BIT(14));
@@ -2089,7 +2089,7 @@ static void phydm_get_set_power_trim_offset_8721d(void *dm_void)
 	}
 }
 
-static void phydm_get_set_pa_bias_offset_8721d(void *dm_void)
+static void __maybe_unused phydm_get_set_pa_bias_offset_8721d(void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct odm_power_trim_data *power_trim_info = &dm->power_trim_data;

--- a/hal/phydm/halrf/halrf_psd.c
+++ b/hal/phydm/halrf/halrf_psd.c
@@ -214,7 +214,7 @@ void halrf_psd(
 		odm_set_bb_reg(dm, psd_reg, 0x3000, avg_org);
 }
 
-static void backup_bb_register(struct dm_struct *dm, u32 *bb_backup, u32 *backup_bb_reg, u32 counter)
+static void __maybe_unused backup_bb_register(struct dm_struct *dm, u32 *bb_backup, u32 *backup_bb_reg, u32 counter)
 {
 	u32 i ;
 
@@ -222,7 +222,7 @@ static void backup_bb_register(struct dm_struct *dm, u32 *bb_backup, u32 *backup
 		bb_backup[i] = odm_get_bb_reg(dm, backup_bb_reg[i], MASKDWORD);
 }
 
-static void restore_bb_register(struct dm_struct *dm, u32 *bb_backup, u32 *backup_bb_reg, u32 counter)
+static void __maybe_unused restore_bb_register(struct dm_struct *dm, u32 *bb_backup, u32 *backup_bb_reg, u32 counter)
 {
 	u32 i ;
 

--- a/hal/phydm/halrf/rtl8822c/halrf_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_8822c.c
@@ -1400,7 +1400,7 @@ void halrf_rxdck_8822c(void *dm_void)
 	odm_set_rf_reg(dm, RF_PATH_A, 0x0, RFREGOFFSETMASK, 0x3ffff);
 	odm_set_rf_reg(dm, RF_PATH_B, 0x0, RFREGOFFSETMASK, 0x3ffff);
 }
-static void _phy_x2_calibrate_8822c(struct dm_struct *dm)
+static void __maybe_unused _phy_x2_calibrate_8822c(struct dm_struct *dm)
 {
 	RF_DBG(dm, DBG_RF_IQK, "[X2K]X2K start!!!!!!!\n");
 	/*X2K*/
@@ -1505,7 +1505,7 @@ boolean _phy_query_rf_path_switch_8822c(void *adapter)
 }
 
 #if ((DM_ODM_SUPPORT_TYPE & ODM_AP) || (DM_ODM_SUPPORT_TYPE == ODM_CE))
-static boolean phy_query_rf_path_switch_8822c(struct dm_struct *dm)
+static boolean __maybe_unused phy_query_rf_path_switch_8822c(struct dm_struct *dm)
 #else
 boolean phy_query_rf_path_switch_8822c(void *adapter)
 #endif

--- a/hal/phydm/halrf/rtl8822c/halrf_dpk_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_dpk_8822c.c
@@ -394,7 +394,7 @@ static void _dpk_manual_txagc_8822c(
 	odm_set_bb_reg(dm, R_0x41a4, BIT(7), is_manual);
 }
 
-static void _dpk_set_txagc_8822c(
+static void __maybe_unused _dpk_set_txagc_8822c(
 	struct dm_struct *dm)
 {
 	odm_set_bb_reg(dm, R_0x18a0, 0x007C0000, 0x1f);
@@ -1248,7 +1248,7 @@ static void _dpk_coef1_read_8822c(
 	odm_set_bb_reg(dm, 0x1b04 + path * 0x58, 0xf0000000, 0x0); /*disable manual coef*/
 }
 
-static void _dpk_coef_default_8822c(
+static void __maybe_unused _dpk_coef_default_8822c(
 	void *dm_void,
 	u8 path)
 {

--- a/hal/phydm/halrf/rtl8822c/halrf_iqk_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_iqk_8822c.c
@@ -80,7 +80,7 @@ _iqk_check_cal_8822c(
 	return false;
 }
 
-static void _iqk_idft(struct dm_struct *dm)
+static void __maybe_unused _iqk_idft(struct dm_struct *dm)
 {
 
 	odm_write_4byte(dm, 0x1b00, 0x8);
@@ -100,7 +100,7 @@ static void _iqk_idft(struct dm_struct *dm)
 	odm_set_bb_reg(dm, R_0x1b20, BIT(31) | BIT(30), 0x0);	
 }
 
-static void _iqk_rx_cfir_check_8822c(struct dm_struct *dm, u8 t)
+static void __maybe_unused _iqk_rx_cfir_check_8822c(struct dm_struct *dm, u8 t)
 {
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
 	u8 j;
@@ -132,7 +132,7 @@ static void _iqk_rx_cfir_check_8822c(struct dm_struct *dm, u8 t)
 }
 
 
-static void _iqk_get_rxcfir_8822c(void *dm_void, u8 path, u8 t)
+static void __maybe_unused _iqk_get_rxcfir_8822c(void *dm_void, u8 path, u8 t)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
@@ -166,7 +166,7 @@ static void _iqk_get_rxcfir_8822c(void *dm_void, u8 path, u8 t)
 //	odm_set_bb_reg(dm, R_0x1bd8, MASKDWORD, 0x0);
 }
 
-static void _iqk_reload_rxcfir_8822c(struct dm_struct *dm, u8 path)
+static void __maybe_unused _iqk_reload_rxcfir_8822c(struct dm_struct *dm, u8 path)
 {
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
 #if 1
@@ -212,7 +212,7 @@ static void _iqk_reload_rxcfir_8822c(struct dm_struct *dm, u8 path)
 #endif
 }
 
-static void _iqk_rx_cfir_8822c(struct dm_struct *dm, u8 path)
+static void __maybe_unused _iqk_rx_cfir_8822c(struct dm_struct *dm, u8 path)
 {
 
 	u32 xym_tmp[6], cfir_tmp[3];
@@ -237,7 +237,7 @@ static void _iqk_rx_cfir_8822c(struct dm_struct *dm, u8 path)
 		path, cfir_tmp[0], cfir_tmp[1], cfir_tmp[2]);
 }
 
-static void _iqk_tx_cfir_8822c(struct dm_struct *dm, u8 path)
+static void __maybe_unused _iqk_tx_cfir_8822c(struct dm_struct *dm, u8 path)
 {
 	u32 xym_tmp[6], cfir_tmp[3];
 	u32 i;
@@ -281,7 +281,7 @@ static u8 _iqk_get_efuse_thermal_8822c(
 
 
 /*---------------------------Define Local Constant---------------------------*/
-static void phydm_get_read_counter_8822c(struct dm_struct *dm)
+static void __maybe_unused phydm_get_read_counter_8822c(struct dm_struct *dm)
 {
 	u32 counter = 0x0;
 
@@ -420,7 +420,7 @@ static void _iqk_information_8822c(
 }
 
 
-static boolean _iqk_xym_read_8822c(struct dm_struct *dm, u8 path)
+static boolean __maybe_unused _iqk_xym_read_8822c(struct dm_struct *dm, u8 path)
 {
 	u32 i = 0x0;
 	u32 xym = 0x0;
@@ -546,7 +546,7 @@ static void _iqk_set_gnt_wl_high_8822c(struct dm_struct *dm)
 	//_iqk_btc_write_indirect_reg_8822c(dm, 0x38, 0x0300, val); /*0x38[9:8]*/
 }
 
-static void _iqk_set_gnt_bt_low_8822c(struct dm_struct *dm)
+static void __maybe_unused _iqk_set_gnt_bt_low_8822c(struct dm_struct *dm)
 {
 	u32 val = 0;
 	u8 state = 0x0, sw_control = 0x1;
@@ -571,7 +571,7 @@ static void _iqk_set_gnt_wl_gnt_bt_8822c(struct dm_struct *dm, boolean beforeK)
 
 
 
-static void _iqk_nctl_8822c(struct dm_struct *dm)
+static void __maybe_unused _iqk_nctl_8822c(struct dm_struct *dm)
 {
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]==========IQK NCTL!!!!!========\n");
 	//odm_write_4byte(dm 0x1CD0, 0x7 [31:28]);	
@@ -2418,7 +2418,7 @@ static void _iqk_cal_path_off_8822c(struct dm_struct *dm)
 	}
 }
 
-static void _iqk_con_tx_8822c(
+static void __maybe_unused _iqk_con_tx_8822c(
 	struct dm_struct *dm,
 	boolean is_contx)
 {
@@ -2459,7 +2459,7 @@ static void _iqk_rf_set_check_8822c(
 	}
 }
 
-static void _iqk_rf0xb0_workaround_8822c(
+static void __maybe_unused _iqk_rf0xb0_workaround_8822c(
 	struct dm_struct *dm)
 {
 	/*add 0xb8 control for the bad phase noise after switching channel*/
@@ -2589,7 +2589,7 @@ static void _iqk_agc_bnd_int_8822c(
 #endif
 }
 
-static void _iqk_bb_reset_8822c(
+static void __maybe_unused _iqk_bb_reset_8822c(
 	struct dm_struct *dm)
 {
 	boolean cca_ing = false;
@@ -2647,7 +2647,7 @@ static void _iqk_bb_for_dpk_setting_8822c(struct dm_struct *dm)
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]_iqk_bb_for_dpk_setting_8822c!!!!\n");
 }
 
-static void _iqk_rf_setting_8822c(struct dm_struct *dm)
+static void __maybe_unused _iqk_rf_setting_8822c(struct dm_struct *dm)
 {	
 	odm_set_bb_reg(dm, 0x1bb8, BIT(20), 0x0);
 	/*TxIQK mode S0,RF0x00[19:16]=0x4*/
@@ -2696,7 +2696,7 @@ static void _iqk_rf_setting_8822c(struct dm_struct *dm)
 	RF_DBG(dm, DBG_RF_IQK, "[IQK]_iqk_rf_setting_8822c RF01!!!!\n");
 }
 
-static void _iqk_set_afe_8822c(struct dm_struct *dm)
+static void __maybe_unused _iqk_set_afe_8822c(struct dm_struct *dm)
 {
 	odm_set_bb_reg(dm, 0x1830, BIT(30), 0x0);
 	odm_set_bb_reg(dm, 0x1860, 0xfffff000, 0xf0001);
@@ -3067,7 +3067,7 @@ _iqk_reload_iqk_8822c(
 	return iqk_info->is_reload;
 }
 
-static void _iqk_rfe_setting_8822c(
+static void __maybe_unused _iqk_rfe_setting_8822c(
 	struct dm_struct *dm,
 	boolean ext_pa_on)
 {
@@ -3098,7 +3098,7 @@ static void _iqk_rfe_setting_8822c(
 #endif
 }
 
-static void _iqk_setrf_bypath_8822c(
+static void __maybe_unused _iqk_setrf_bypath_8822c(
 	struct dm_struct *dm)
 {
 	u8 path;
@@ -3132,7 +3132,7 @@ static void _iqk_rf_direct_access_8822c(
 	*/
 }
 
-static void _iqk_bbtx_path_8822c(
+static void __maybe_unused _iqk_bbtx_path_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -3152,7 +3152,7 @@ static void _iqk_bbtx_path_8822c(
 	odm_set_bb_reg(dm, 0x824, 0xf0000, temp2);
 }
 
-static void _iqk_iqk_mode_8822c(
+static void __maybe_unused _iqk_iqk_mode_8822c(
 	struct dm_struct *dm,
 	boolean is_iqkmode)
 {
@@ -3268,7 +3268,7 @@ static void _iqk_lok_setting_8822c(
 		odm_set_bb_reg(dm, 0x1b2c, 0xfff, 0x38);
 }
 
-static void _iqk_reload_lok_setting_8822c(
+static void __maybe_unused _iqk_reload_lok_setting_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -3495,7 +3495,7 @@ static void _iqk_rxk2_setting_8822c(
 
 
 static void
-_iqk_set_lok_lut_8822c(
+__maybe_unused _iqk_set_lok_lut_8822c(
 	struct dm_struct *dm,
 	u8 path)
 {
@@ -3979,7 +3979,7 @@ static void _iqk_lok_tune_8822c(void *dm_void, u8 path)
 }
 
 static boolean
-_lok_load_default_8822c(void *dm_void, u8 path)
+__maybe_unused _lok_load_default_8822c(void *dm_void, u8 path)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;
@@ -4223,7 +4223,7 @@ static void _iqk_iqk_by_path_8822c(
 
 }
 
-static void _iqk_dpd_in_sel(
+static void __maybe_unused _iqk_dpd_in_sel(
 	struct dm_struct *dm,
 	u8 input)
 {
@@ -4388,7 +4388,7 @@ static u32 _iqk_tximr_selfcheck_8822c(
 	return tximr;
 }
 
-static void _iqk_start_tximr_test_8822c(
+static void __maybe_unused _iqk_start_tximr_test_8822c(
 	struct dm_struct *dm,
 	u8 imr_limit)
 {
@@ -4628,7 +4628,7 @@ static void _iqk_start_rximr_test_8822c(
 		_iqk_rximr_test_8822c(dm, path, imr_limit);
 }
 
-static void _iqk_start_imr_test_8822c(
+static void __maybe_unused _iqk_start_imr_test_8822c(
 	void *dm_void)
 {
 	u8 imr_limit;
@@ -4909,7 +4909,7 @@ void iqk_set_cfir_8822c(void *dm_void, u8 idx, u8 path, boolean debug)
 }
 
 
-static void iqk_clean_cfir_8822c(void *dm_void, u8 mode, u8 path)
+static void __maybe_unused iqk_clean_cfir_8822c(void *dm_void, u8 mode, u8 path)
 {	
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
 	struct dm_iqk_info *iqk_info = &dm->IQK_info;	

--- a/hal/phydm/halrf/rtl8822c/halrf_tssi_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_tssi_8822c.c
@@ -152,7 +152,7 @@ static u8 _halrf_tssi_rate_to_driver_rate_8822c(
 	return driver_rate;
 }
 
-static void _halrf_calculate_txagc_codeword_8822c(
+static void __maybe_unused _halrf_calculate_txagc_codeword_8822c(
 	void *dm_void, u16 *tssi_value,  s16 *txagc_value)
 {
 #if 0
@@ -232,7 +232,7 @@ static u32 _halrf_get_efuse_tssi_offset_8822c(
 	return offset;
 }
 
-static s8 _halrf_get_kfree_tssi_offset_8822c(
+static s8 __maybe_unused _halrf_get_kfree_tssi_offset_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -590,7 +590,7 @@ static void _halrf_calculate_set_thermal_codeword_8822c(
 		odm_set_bb_reg(dm, R_0x1c20, 0x03f00000, 0x0);
 }
 
-static void _halrf_set_txagc_codeword_8822c(
+static void __maybe_unused _halrf_set_txagc_codeword_8822c(
 	void *dm_void, s16 *tssi_value)
 {
 #if 0
@@ -634,7 +634,7 @@ void halrf_set_tssi_codeword_8822c(
 	}
 }
 
-static void _halrf_set_efuse_kfree_offset_8822c(
+static void __maybe_unused _halrf_set_efuse_kfree_offset_8822c(
 	void *dm_void)
 {
 #if 0
@@ -1165,7 +1165,7 @@ static void _halrf_tssi_scan_8822c(
 	}
 }
 
-static void _halrf_thermal_init_8822c(
+static void __maybe_unused _halrf_thermal_init_8822c(
 	void *dm_void)
 {
 #if 0

--- a/hal/phydm/halrf/rtl8822c/halrf_txgapk_8822c.c
+++ b/hal/phydm/halrf/rtl8822c/halrf_txgapk_8822c.c
@@ -657,7 +657,7 @@ static void _halrf_txgapk_write_tx_gain_8822c(
 	}
 }
 
-static void _halrf_txgapk_disable_power_trim_8822c(
+static void __maybe_unused _halrf_txgapk_disable_power_trim_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;
@@ -672,7 +672,7 @@ static void _halrf_txgapk_disable_power_trim_8822c(
 
 }
 
-static void _halrf_txgapk_enable_power_trim_8822c(
+static void __maybe_unused _halrf_txgapk_enable_power_trim_8822c(
 	void *dm_void)
 {
 	struct dm_struct *dm = (struct dm_struct *)dm_void;

--- a/hal/phydm/phydm_api.c
+++ b/hal/phydm/phydm_api.c
@@ -1713,7 +1713,7 @@ u8 phydm_phystat_rpt_jgr3(void *dm_void, enum phystat_rpt info,
 	return return_info;
 }
 
-static void phydm_ex_hal8814b_wifi_only_hw_config(void *dm_void)
+static void __maybe_unused phydm_ex_hal8814b_wifi_only_hw_config(void *dm_void)
 {
 	/*BB control*/
 	/*halwifionly_phy_set_bb_reg(pwifionlycfg, 0x4c, 0x01800000, 0x2);*/

--- a/hal/phydm/phydm_phystatus.c
+++ b/hal/phydm/phydm_phystatus.c
@@ -1852,7 +1852,7 @@ static void phydm_print_phystat_jgr3(struct dm_struct *dm, u8 *phy_sts,
 	}
 }
 
-static void phydm_reset_phy_info_jgr3(struct dm_struct *phydm,
+static void __maybe_unused phydm_reset_phy_info_jgr3(struct dm_struct *phydm,
 			       struct phydm_phyinfo_struct *phy_info)
 {
 	u8 i;

--- a/hal/phydm/phydm_rainfo.c
+++ b/hal/phydm/phydm_rainfo.c
@@ -1587,7 +1587,7 @@ u8 phydm_rssi_lv_dec(void *dm_void, u32 rssi, u8 ratr_state)
 	return new_rssi_lv;
 }
 
-static enum phydm_qam_order phydm_get_ofdm_qam_order(void *dm_void, u8 rate_idx)
+static enum phydm_qam_order __maybe_unused phydm_get_ofdm_qam_order(void *dm_void, u8 rate_idx)
 {
 	u8 tmp_idx = rate_idx;
 	enum phydm_qam_order qam_order = PHYDM_QAM_BPSK;

--- a/hal/rtl8822c/rtl8822c_phy.c
+++ b/hal/rtl8822c/rtl8822c_phy.c
@@ -2006,7 +2006,7 @@ static void _reset_beamformee_mu(PADAPTER adapter, struct beamformee_entry *bfee
 	RTW_INFO("%s: Clear MU BFee entry(%d) HW setting\n", __FUNCTION__, idx);
 }
 
-static void rtl8822c_phy_bf_reset_all(PADAPTER adapter)
+static void __maybe_unused rtl8822c_phy_bf_reset_all(PADAPTER adapter)
 {
 	struct beamforming_info *info;
 	u8 i, val8;


### PR DESCRIPTION
53 static functions have no live caller in the default build — they are dead, or only reachable from code under a disabled `#ifdef` / `#if 0`. After #24 made them `static`, they trip `-Wunused-function`.

Mark them `__maybe_unused` (= `__attribute__((unused))`), the kernel-standard way to keep a possibly-unused symbol without the warning. **No codegen or behavior change** — the attribute only suppresses the diagnostic.

Complements **#30** (which `#ifdef`-guards the 18 functions whose sole caller sits under a real config/chip macro — the cleaner fix where it applies). Together the default build is `-Wunused-function`-clean.

Build-verified (x86_64, v7.1, `make defconfig` → CONFIG_WERROR=y): `-Wunused-function` 71 → 18 (the remaining 18 are #30's), 0 errors, no functional change.