### PR TITLE
osdep: mark thread_exit __noreturn (fix objtool build error)

### DIFF
--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -425,7 +425,7 @@ static __inline void thread_enter(char *name)
 	printf("%s", "RTKTHREAD_enter");
 #endif
 }
-void thread_exit(_completion *comp);
+void __noreturn thread_exit(_completion *comp);
 void _rtw_init_completion(_completion *comp);
 void _rtw_wait_for_comp_timeout(_completion *comp);
 void _rtw_wait_for_comp(_completion *comp);

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1306,7 +1306,7 @@ u32 _rtw_down_sema(_sema *sema)
 #endif
 }
 
-inline void thread_exit(_completion *comp)
+inline void __noreturn thread_exit(_completion *comp)
 {
 #ifdef PLATFORM_LINUX
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))


### PR DESCRIPTION
`thread_exit()` ends the calling kthread via `kthread_complete_and_exit()` (`complete_and_exit()` pre-5.17) and never returns, but was not annotated.

On kernels built with `CONFIG_OBJTOOL_WERROR=y` (e.g. `x86_64_defconfig`, which the CI now uses) objtool turns the warning

> `mp_xmit_packet_thread: thread_exit() is missing a __noreturn annotation`

into a **fatal build error** — this is what currently reds the CI on `tune_for_jethub` (the -Wmissing-prototypes/-Wunused-function classes are already clean after #27/#28/#30/#32).

Fix: annotate the declaration and definition `__noreturn`. The `PLATFORM_LINUX` paths are genuinely noreturn, so the annotation is correct and introduces no 'noreturn does return' warning.

Build-verified (x86_64, v7.1, `make defconfig` → OBJTOOL_WERROR=y): objtool-clean, 0 errors, 0 -Wunused-function. No functional change.