### PR TITLE
ci: full kernel build so module symbols resolve (vs modules_prepare)

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -120,7 +120,10 @@ jobs:
           scripts/config --set-str SYSTEM_REVOCATION_KEYS ""
           # Reconcile and prepare for external module builds
           make olddefconfig
-          make modules_prepare
+          # Build the kernel fully so Module.symvers exists and the out-of-tree
+          # module's references to exported kernel symbols resolve (a
+          # modules_prepare-only tree has no symvers -> spurious modpost undefineds).
+          make -j"$(nproc)"
           
       - name: Build module
         run: |


### PR DESCRIPTION
Experiment to compare against the modules_prepare-only setup.

The CI prepared the kernel with only `make modules_prepare` → no `Module.symvers`, so modpost flags 200+ exported kernel symbols the module uses (`cfg80211_*`, `snprintf`, `skb_clone`, …) as **undefined** and `make` exits non-zero, failing the job even though the module compiles and links cleanly.

This builds the kernel fully (`make -j$(nproc)`) so `Module.symvers` exists and the module's references resolve — modpost should be clean.

Stacks on the `thread_exit` `__noreturn` objtool fix (#33) so the only new variable is modpost. Trade-off: a full kernel build per matrix entry is slower.