### PR TITLE
ci: keep a clean build green (diagnostics grep must not fail on no-match)

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -141,12 +141,17 @@ jobs:
 
           # Count diagnostics by type (gcc prints the class in brackets, e.g.
           # [-Werror=missing-prototypes]). Pure shell, no extra tooling.
+          # NOTE: trailing '|| true' — a CLEAN build has zero [-W...] matches, so grep
+          # exits 1; under 'set -e -o pipefail' that would fail an otherwise green
+          # build. '|| true' on the whole pipeline keeps clean == green. (It must be on
+          # the pipeline tail: '{ grep || true; } | ...' does NOT work — pipefail still
+          # surfaces grep's 1 from inside the group.)
           echo "### ${{ matrix.kernel_version }} — diagnostics by type" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           grep -hoE '\[-W[A-Za-z0-9=_+-]+\]' "$LOG" \
             | sed -E 's/^\[-W(error=)?//; s/\]$//' \
             | sort | uniq -c | sort -rn \
-            | tee -a "$GITHUB_STEP_SUMMARY"
+            | tee -a "$GITHUB_STEP_SUMMARY" || true
           total=$(grep -c ': error:' "$LOG" || true)
           echo "error: lines (hard compile errors): ${total:-0}" | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
**Root cause of the all-red matrix** — and it is the CI script, not the driver.

The `Build module` step compiles fine, but its *diagnostics-by-type* tally runs under `set -e -o pipefail`:
```
grep -hoE '\[-W...\]' "$LOG" | sed ... | sort | uniq -c | tee -a "$GITHUB_STEP_SUMMARY"
```
Once the driver became warning-clean (objtool fixed in #33, every `-W` class at 0), the grep matches **nothing** and exits 1 → `pipefail` propagates it → the step fails an *otherwise green* build. The log proves it: it ends right after `make[1]: Leaving directory` with **no** summary printed — the script died at the grep, not in `make` (which returned 0).

Fix: `{ grep ... || true; }` so a clean build yields an empty list and stays green.

Notes:
- modpost "undefined symbol" notes were already non-fatal via `KBUILD_MODPOST_WARN=1` — they were never the blocker, so **no full kernel build is needed** (that experiment, #34, is superseded by this).
- Stacked on #33 (`thread_exit __noreturn`); merge #33 first and this reduces to just the grep change.