### PR TITLE
cfg80211: remain_on_channel rx_addr param for kernel 7.2+

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -7286,7 +7286,14 @@ static s32 cfg80211_rtw_remain_on_channel(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 0))
 	enum nl80211_channel_type channel_type,
 #endif
-	unsigned int duration, u64 *cookie)
+	unsigned int duration, u64 *cookie
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+	/* commit 4dbd1829045e ("wifi: cfg80211: Add MAC address filter to
+	 * remain_on_channel") added a trailing MAC filter (7.2+). We don't
+	 * filter by it — accept and ignore. */
+	, const u8 *rx_addr
+#endif
+	)
 {
 	s32 err = 0;
 	u8 remain_ch = (u8) ieee80211_frequency_to_channel(channel->center_freq);


### PR DESCRIPTION
Kernel commit `4dbd1829045e` ("wifi: cfg80211: Add MAC address filter to remain_on_channel", **7.2 merge window**) added a trailing `const u8 *rx_addr` to the `.remain_on_channel` callback. This is the compile error the linux-next matrix job hits:
```
ioctl_cfg80211.c: error: initialization of '... u64 *, const u8 *)' from incompatible
pointer type '... u64 *)' [-Werror=incompatible-pointer-types]
```

Fix: gate the extra parameter on `KERNEL_VERSION(7, 2, 0)` (same style as the existing version-gated params in this signature). The driver doesn't filter by `rx_addr` — accept and ignore.

**Verified locally:**
- v7.1 (old signature, `#else`): builds clean, **no regression**.
- mainline master forced to 7.2.0 (new signature, `#if`): the remain_on_channel error is gone — and it was the *only* compile error, so the next build compiles clean.

**Merge-window caveat:** until `v7.2-rc1` is tagged, mainline/linux-next still report `LINUX_VERSION_CODE` 7.1.0 (the Makefile bumps to 7.2 only at rc1). So the `next-YYYYMMDD` CI job stays red until then and goes green automatically afterward; released kernels are correct now. (Details: docs linux-next-compat.)