### PR TITLE
fix: replace strncpy() removed in kernel 7.2

### DIFF
--- a/core/rtw_debug.c
+++ b/core/rtw_debug.c
@@ -646,7 +646,7 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				char tmp_str[10] = {'\0'};
 
 				len = snprintf(tmp_str, sizeof(tmp_str), "%s", "ap_id:");
-				strncpy(p, tmp_str, len);
+				rtw_bytes(p, tmp_str, len);
 				p += len;
 				_rtw_memset(&tmp_str, '\0', sizeof(tmp_str));
 				#ifdef DBG_HW_PORT
@@ -654,7 +654,7 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				#else
 				len = snprintf(tmp_str, sizeof(tmp_str), "%d", iface->vap_id);
 				#endif
-				strncpy(p, tmp_str, len);
+				rtw_bytes(p, tmp_str, len);
 			}
 			#endif
 			#ifdef CONFIG_CLIENT_PORT_CFG
@@ -664,7 +664,7 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				char tmp_str[10] = {'\0'};
 
 				len = snprintf(tmp_str, sizeof(tmp_str), "%s", "c_pid:");
-				strncpy(p, tmp_str, len);
+				rtw_bytes(p, tmp_str, len);
 				p += len;
 				_rtw_memset(&tmp_str, '\0', sizeof(tmp_str));
 				#ifdef DBG_HW_PORT
@@ -672,7 +672,7 @@ void dump_adapters_status(void *sel, struct dvobj_priv *dvobj)
 				#else
 				len = snprintf(tmp_str, sizeof(tmp_str), "%d", iface->client_port);
 				#endif
-				strncpy(p, tmp_str, len);
+				rtw_bytes(p, tmp_str, len);
 			}
 			#endif
 
@@ -7461,11 +7461,11 @@ inline void RTW_BUF_DUMP_SEL(uint _loglevel, void *sel, u8 *_titlestring,
 		if (_titlestring) {
 			if (sel == RTW_DBGDUMP) {
 				len = snprintf(str_val, sizeof(str_val), "%s", DRIVER_PREFIX);
-				strncpy(p, str_val, len);
+				rtw_bytes(p, str_val, len);
 				p += len;
 			}
 			len = snprintf(str_val, sizeof(str_val), "%s", _titlestring);
-			strncpy(p, str_val, len);
+			rtw_bytes(p, str_val, len);
 			p += len;
 		}
 		if (p != &str_out[0]) {
@@ -7480,18 +7480,18 @@ inline void RTW_BUF_DUMP_SEL(uint _loglevel, void *sel, u8 *_titlestring,
 			p = &str_out[0];
 			if (sel == RTW_DBGDUMP) {
 				len = snprintf(str_val, sizeof(str_val), "%s", DRIVER_PREFIX);
-				strncpy(p, str_val, len);
+				rtw_bytes(p, str_val, len);
 				p += len;
 			}
 			if (_idx_show) {
 				len = snprintf(str_val, sizeof(str_val), "0x%03X: ", __i * RTW_BUFDUMP_BSIZE);
-				strncpy(p, str_val, len);
+				rtw_bytes(p, str_val, len);
 				p += len;
 			}
 			for (__j =0; __j < RTW_BUFDUMP_BSIZE; __j++) {
 				idx = __i * RTW_BUFDUMP_BSIZE + __j;
 				len = snprintf(str_val, sizeof(str_val), "%02X%s", ptr[idx], (((__j + 1) % 4) == 0) ? "  " : " ");
-				strncpy(p, str_val, len);
+				rtw_bytes(p, str_val, len);
 				p += len;
 			}
 			_RTW_STR_DUMP_SEL(sel, str_out);
@@ -7501,18 +7501,18 @@ inline void RTW_BUF_DUMP_SEL(uint _loglevel, void *sel, u8 *_titlestring,
 		p = &str_out[0];
 		if ((sel == RTW_DBGDUMP) && remain_byte) {
 			len = snprintf(str_val, sizeof(str_val), "%s", DRIVER_PREFIX);
-			strncpy(p, str_val, len);
+			rtw_bytes(p, str_val, len);
 			p += len;
 		}
 		if (_idx_show && remain_byte) {
 			len = snprintf(str_val, sizeof(str_val), "0x%03X: ", block_num * RTW_BUFDUMP_BSIZE);
-			strncpy(p, str_val, len);
+			rtw_bytes(p, str_val, len);
 			p += len;
 		}
 		for (__i = 0; __i < remain_byte; __i++) {
 			idx = block_num * RTW_BUFDUMP_BSIZE + __i;
 			len = snprintf(str_val, sizeof(str_val), "%02X%s", ptr[idx], (((__i + 1) % 4) == 0) ? "  " : " ");
-			strncpy(p, str_val, len);
+			rtw_bytes(p, str_val, len);
 			p += len;
 		}
 		_RTW_STR_DUMP_SEL(sel, str_out);

--- a/hal/hal_com.c
+++ b/hal/hal_com.c
@@ -13179,7 +13179,7 @@ ParseQualifiedString(
 		return _FALSE;
 
 	j = (*Start) - 2;
-	strncpy((char *)Out, (const char *)(In + i), j - i + 1);
+	rtw_bytes((char *)Out, (const char *)(In + i), j - i + 1);
 
 	return _TRUE;
 }

--- a/hal/hal_com_phycfg.c
+++ b/hal/hal_com_phycfg.c
@@ -5106,9 +5106,9 @@ PHY_ConfigRFWithTxPwrTrackParaFile(
 				if (strlen(szLine) < 10 || szLine[0] != '[')
 					continue;
 
-				strncpy(band, szLine + 1, 2);
-				strncpy(path, szLine + 5, 1);
-				strncpy(sign, szLine + 8, 1);
+				rtw_bytes(band, szLine + 1, 2);
+				rtw_bytes(path, szLine + 5, 1);
+				rtw_bytes(sign, szLine + 8, 1);
 
 				i = 10; /* szLine+10 */
 				if (!ParseQualifiedString(szLine, &i, rate, '[', ']')) {

--- a/hal/hal_hci/hal_sdio.c
+++ b/hal/hal_hci/hal_sdio.c
@@ -37,13 +37,13 @@ static void dump_mac_page0(PADAPTER padapter)
 		p = &str_out[0];
 		len = snprintf(str_val, sizeof(str_val),
 			       "0x%02x: ", index);
-		strncpy(str_out, str_val, len);
+		rtw_bytes(str_out, str_val, len);
 		p += len;
 
 		for (i = 0 ; i < 16 ; i++) {
 			len = snprintf(str_val, sizeof(str_val), "%02x ",
 				       rtw_read8(padapter, index + i));
-			strncpy(p, str_val, len);
+			rtw_bytes(p, str_val, len);
 			p += len;
 		}
 		RTW_INFO("%s\n", str_out);

--- a/hal/phydm/phydm_debug.c
+++ b/hal/phydm/phydm_debug.c
@@ -5614,7 +5614,7 @@ void phydm_fw_trace_handler(void *dm_void, u8 *cmd_buf, u8 cmd_len)
 		  "[FW debug message] freg_num = (( %d )), c2h_seq=(( %d ))\n",
 		  freg_num, c2h_seq);
 
-	strncpy(debug_trace_11byte, &cmd_buf[1], (cmd_len - 1));
+	rtw_bytes(debug_trace_11byte, &cmd_buf[1], (cmd_len - 1));
 	debug_trace_11byte[cmd_len - 1] = '\0';
 	PHYDM_DBG(dm, DBG_FW_TRACE, "[FW debug message] %s\n",
 		  debug_trace_11byte);
@@ -5645,7 +5645,7 @@ void phydm_fw_trace_handler(void *dm_void, u8 *cmd_buf, u8 cmd_len)
 		return;
 	}
 
-	strncpy((char *)&dm->fw_debug_trace[dm->c2h_cmd_start],
+	rtw_bytes((char *)&dm->fw_debug_trace[dm->c2h_cmd_start],
 		(char *)&cmd_buf[1], (cmd_len - 1));
 	dm->c2h_cmd_start += (cmd_len - 1);
 	dm->fw_buff_is_enpty = false;

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -822,4 +822,24 @@ int hexstr2bin(const char *hex, u8 *buf, size_t len);
 #error "NOT DEFINE \"rtw_sprintf\"!!"
 #endif /* !PLATFORM_LINUX */
 
+/*
+ * strncpy() was removed from the kernel in v7.2 (commit 079a028d6327,
+ * "string: Remove strncpy() from the kernel"). Provide intent-named wrappers:
+ * on >= 7.2 they map to the semantically-correct FORTIFY-friendly replacement;
+ * on <= 7.1 strncpy() is still present, so they expand to it unchanged
+ * (byte-identical behavior, zero risk on already-supported kernels).
+ */
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
+/* C-string -> sized buffer: NUL-terminated AND tail-padded with NUL. Matches
+ * strncpy() for sources shorter than size (holds at every call site here). */
+#define rtw_strscpy_pad(dst, src, size)	strscpy_pad((dst), (src), (size))
+/* Copy exactly n raw bytes, no termination/padding: either n != sizeof(dst),
+ * or src is a non-NUL-terminated blob. Termination (when dst is later used as a
+ * C-string) is guaranteed by surrounding code / pre-zeroed buffers. */
+#define rtw_bytes(dst, src, n)		memcpy((dst), (src), (n))
+#else
+#define rtw_strscpy_pad(dst, src, size)	strncpy((dst), (src), (size))
+#define rtw_bytes(dst, src, n)		strncpy((dst), (src), (n))
+#endif
+
 #endif

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -2034,7 +2034,7 @@ static int cfg80211_rtw_add_key(struct wiphy *wiphy,
 		goto addkey_end;
 	}
 
-	strncpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+	rtw_strscpy_pad((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
 
 
 	if (!mac_addr || is_broadcast_ether_addr(mac_addr)
@@ -5190,7 +5190,7 @@ static int rtw_cfg80211_add_monitor_if(_adapter *padapter, char *name, struct ne
 	}
 
 	mon_ndev->type = ARPHRD_IEEE80211_RADIOTAP;
-	strncpy(mon_ndev->name, name, IFNAMSIZ);
+	rtw_strscpy_pad(mon_ndev->name, name, IFNAMSIZ);
 	mon_ndev->name[IFNAMSIZ - 1] = 0;
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(4, 11, 8))
 	mon_ndev->priv_destructor = rtw_ndev_destructor;

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -3145,7 +3145,7 @@ static int rtw_wx_set_enc_ext(struct net_device *dev,
 		goto exit;
 	}
 
-	strncpy((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
+	rtw_strscpy_pad((char *)param->u.crypt.alg, alg_name, IEEE_CRYPT_ALG_NAME_LEN);
 
 	if (pext->ext_flags & IW_ENCODE_EXT_SET_TX_KEY)
 		param->u.crypt.set_tx = 1;
@@ -5773,7 +5773,7 @@ static int rtw_rereg_nd_name(struct net_device *dev,
 #endif
 			reg_ifname = padapter->registrypriv.if2name;
 
-		strncpy(rereg_priv->old_ifname, reg_ifname, IFNAMSIZ);
+		rtw_strscpy_pad(rereg_priv->old_ifname, reg_ifname, IFNAMSIZ);
 		rereg_priv->old_ifname[IFNAMSIZ - 1] = 0;
 	}
 
@@ -5798,7 +5798,7 @@ static int rtw_rereg_nd_name(struct net_device *dev,
 		/* rtw_ips_mode_req(&padapter->pwrctrlpriv, rereg_priv->old_ips_mode); */
 	}
 
-	strncpy(rereg_priv->old_ifname, new_ifname, IFNAMSIZ);
+	rtw_bytes(rereg_priv->old_ifname, new_ifname, IFNAMSIZ);
 	rereg_priv->old_ifname[IFNAMSIZ - 1] = 0;
 
 	if (_rtw_memcmp(new_ifname, "disable%d", 9) == _TRUE) {

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1734,7 +1734,7 @@ static int rtw_ndev_init(struct net_device *dev)
 
 	RTW_PRINT(FUNC_ADPT_FMT" if%d mac_addr="MAC_FMT"\n"
 		, FUNC_ADPT_ARG(adapter), (adapter->iface_id + 1), MAC_ARG(dev->dev_addr));
-	strncpy(adapter->old_ifname, dev->name, IFNAMSIZ);
+	rtw_strscpy_pad(adapter->old_ifname, dev->name, IFNAMSIZ);
 	adapter->old_ifname[IFNAMSIZ - 1] = '\0';
 	rtw_adapter_proc_init(dev);
 

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -1387,7 +1387,7 @@ static int rtw_cfgvendor_logger_start_logging(struct wiphy *wiphy,
 		type = nla_type(iter);
 		switch (type) {
 			case LOGGER_ATTRIBUTE_RING_NAME:
-				strncpy(ring_name, nla_data(iter),
+				rtw_bytes(ring_name, nla_data(iter),
 					MIN(sizeof(ring_name) -1, nla_len(iter)));
 				break;
 			case LOGGER_ATTRIBUTE_LOG_LEVEL:
@@ -1516,7 +1516,7 @@ static int rtw_cfgvendor_logger_get_ring_data(struct wiphy *wiphy,
 		type = nla_type(iter);
 		switch (type) {
 			case LOGGER_ATTRIBUTE_RING_NAME:
-				strncpy(ring_name, nla_data(iter),
+				rtw_bytes(ring_name, nla_data(iter),
 					MIN(sizeof(ring_name) -1, nla_len(iter)));
 				RTW_INFO(" %s LOGGER_ATTRIBUTE_RING_NAME : %s\n", __func__, ring_name);
 				break;


### PR DESCRIPTION
## Problem

Kernel **7.2 removed `strncpy()` entirely** (commit `079a028d6327`, *"string: Remove strncpy() from the kernel"* — the final step of the long campaign to eliminate `strncpy`). The out-of-tree build fails on `v7.2-rc1` with `-Werror=implicit-function-declaration` / `builtin-declaration-mismatch` across **28 call sites in 9 files**. On `<=7.1` (5.x/6.x/7.1) `strncpy` is still present.

This is the second (and last) 7.2 merge-window incompatibility; the first — `remain_on_channel` — was closed in #38.

## Fix

Intent-named wrappers in `include/osdep_service.h`, gated at the **removal point** `KERNEL_VERSION(7,2,0)`; the `#else` branch keeps the original `strncpy` → older kernels stay **byte-identical, zero risk**:

```c
#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 2, 0))
#define rtw_strscpy_pad(dst, src, size)  strscpy_pad((dst), (src), (size))
#define rtw_bytes(dst, src, n)           memcpy((dst), (src), (n))
#else
#define rtw_strscpy_pad(dst, src, size)  strncpy((dst), (src), (size))
#define rtw_bytes(dst, src, n)           strncpy((dst), (src), (n))
#endif
```

Per-site classification (each call's semantics analyzed individually):
- **`rtw_strscpy_pad` — 5** string sites (`crypt.alg` x2; ifname from a kernel C-string x3): NUL-terminated + padded = byte-identical to `strncpy` for the short sources here.
- **`rtw_bytes` — 23** sites: fixed-column parsing, FW/netlink blobs (src not NUL-terminated -> `strscpy` would over-read), snprintf chunk appends, user-supplied ifname (src from `copy_from_user`).

The choice is not mechanical: e.g. `strscpy(band, ..., 2)` would copy only **1** char instead of 2 (it reserves a byte for the NUL) — that site needs `memcpy`.

## Verification

Built clean against **`v7.2-rc1`** with **`CONFIG_FORTIFY_SOURCE=y`**: `rc=0`, 0 errors, 0 FORTIFY warnings, `88x2cs.ko` builds. The `#else` branch (older kernels) is the unchanged original code by construction.

Diff: 10 files, +48/-28.